### PR TITLE
Fix #9 Client should support create call

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ public interface ModelServerClientApiV1<A> {
 
    CompletableFuture<Response<Boolean>> delete(String modelUri);
 
-   CompletableFuture<Response<String>> update(String modelUri, String updatedModel);
+   CompletableFuture<Response<String>> create(String modelUri, String createdModelAsJsonText);
+
+   CompletableFuture<Response<A>> create(String modelUri, A createdModel, String format);
+
+   CompletableFuture<Response<String>> update(String modelUri, String updatedModelAsJsonText);
 
    CompletableFuture<Response<A>> update(String modelUri, A updatedModel, String format);
 

--- a/org.eclipse.emfcloud.modelserver.client/src/main/java/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/org.eclipse.emfcloud.modelserver.client/src/main/java/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.ecore.EObject;
@@ -42,6 +41,7 @@ import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 
@@ -159,41 +159,45 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
       final Request request = buildCreateOrUpdateRequest(modelUri, POST, "json", dataNode);
 
       return makeCall(request)
-              .thenApply(response -> parseField(response, "data"))
-              .thenApply(this::getBodyOrThrow);
+         .thenApply(response -> parseField(response, "data"))
+         .thenApply(this::getBodyOrThrow);
    }
 
    @Override
    public CompletableFuture<Response<EObject>> create(final String modelUri, final EObject createdModel,
-                                                      final String format) {
+      final String format) {
       return createOrUpdateModel(modelUri, createdModel, format, POST);
    }
 
-   private CompletableFuture<Response<EObject>> createOrUpdateModel(String modelUri, EObject model, String format, String httpMethod) {
+   private CompletableFuture<Response<EObject>> createOrUpdateModel(final String modelUri, final EObject model,
+      final String format,
+      final String httpMethod) {
       String checkedFormat = checkedFormat(format);
       TextNode dataNode = Json.text(encode(model, checkedFormat));
       final Request request = buildCreateOrUpdateRequest(modelUri, httpMethod, checkedFormat, dataNode);
 
       return makeCall(request)
-              .thenApply(response -> parseField(response, "data"))
-              .thenApply(resp -> resp.mapBody(body -> body.flatMap(b -> decode(b, checkedFormat))))
-              .thenApply(this::getBodyOrThrow);
+         .thenApply(response -> parseField(response, "data"))
+         .thenApply(resp -> resp.mapBody(body -> body.flatMap(b -> decode(b, checkedFormat))))
+         .thenApply(this::getBodyOrThrow);
    }
 
    @NotNull
-   private Request buildCreateOrUpdateRequest(String modelUri, String httpMethod, String checkedFormat, TextNode dataNode) {
+   private Request buildCreateOrUpdateRequest(final String modelUri, final String httpMethod,
+      final String checkedFormat,
+      final TextNode dataNode) {
       return new Request.Builder()
-                .url(
-                        createHttpUrlBuilder(makeUrl(MODEL_BASE_PATH))
-                                .addQueryParameter("modeluri", modelUri)
-                                .addQueryParameter("format", checkedFormat)
-                                .build())
-                .method(httpMethod,
-                        RequestBody.create(
-                                Json.object(
-                                        Json.prop("data", dataNode)).toString(),
-                                MediaType.parse("application/json")))
-                .build();
+         .url(
+            createHttpUrlBuilder(makeUrl(MODEL_BASE_PATH))
+               .addQueryParameter("modeluri", modelUri)
+               .addQueryParameter("format", checkedFormat)
+               .build())
+         .method(httpMethod,
+            RequestBody.create(
+               Json.object(
+                  Json.prop("data", dataNode)).toString(),
+               MediaType.parse("application/json")))
+         .build();
    }
 
    @Override

--- a/org.eclipse.emfcloud.modelserver.client/src/main/java/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
+++ b/org.eclipse.emfcloud.modelserver.client/src/main/java/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
@@ -27,7 +27,11 @@ public interface ModelServerClientApiV1<A> {
 
    CompletableFuture<Response<Boolean>> delete(String modelUri);
 
-   CompletableFuture<Response<String>> update(String modelUri, String updatedModel);
+   CompletableFuture<Response<String>> create(String modelUri, String createdModelAsJsonText);
+
+   CompletableFuture<Response<A>> create(String modelUri, A createdModel, String format);
+
+   CompletableFuture<Response<String>> update(String modelUri, String updatedModelAsJsonText);
 
    CompletableFuture<Response<A>> update(String modelUri, A updatedModel, String format);
 

--- a/org.eclipse.emfcloud.modelserver.client/src/test/java/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
+++ b/org.eclipse.emfcloud.modelserver.client/src/test/java/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
@@ -137,10 +137,45 @@ public class ModelServerClientTest {
 
    @Test
    @SuppressWarnings({ "checkstyle:ThrowsCount" })
+   public void create() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
+      final JsonNode expected = jsonCodec.encode(display);
+      interceptor.addRule()
+              .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=json")
+              .post()
+              .respond(JsonResponse.success(expected).toString());
+      ModelServerClient client = createClient();
+
+      final CompletableFuture<Response<String>> f = client.create(
+              "SuperBrewer3000.json",
+              expected.toString());
+
+      assertThat(f.get().body(), equalTo(expected.toString()));
+   }
+
+   @Test
+   @SuppressWarnings({ "checkstyle:ThrowsCount" })
+   public void createModel() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
+      final JsonNode expected = jsonCodec.encode(display);
+      interceptor.addRule()
+              .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=json")
+              .post()
+              .respond(JsonResponse.success(expected).toString());
+      ModelServerClient client = createClient();
+
+      CompletableFuture<Response<EObject>> f = client.create(
+              "SuperBrewer3000.json",
+              display,
+              "json");
+
+      assertThat(jsonCodec.encode(f.get().body()), equalTo(expected));
+   }
+
+   @Test
+   @SuppressWarnings({ "checkstyle:ThrowsCount" })
    public void update() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
       final JsonNode expected = jsonCodec.encode(display);
       interceptor.addRule()
-         .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=" + "SuperBrewer3000.json")
+         .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=json")
          .patch()
          .respond(JsonResponse.success(expected).toString());
       ModelServerClient client = createClient();

--- a/org.eclipse.emfcloud.modelserver.client/src/test/java/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
+++ b/org.eclipse.emfcloud.modelserver.client/src/test/java/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
@@ -34,10 +34,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.edit.command.AddCommand;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.emfjson.jackson.resource.JsonResource;
-import org.junit.Before;
-import org.junit.Test;
-
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.BrewingUnit;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeeFactory;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeePackage;
@@ -53,6 +49,10 @@ import org.eclipse.emfcloud.modelserver.common.codecs.XmiCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.JsonResponse;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
+import org.emfjson.jackson.resource.JsonResource;
+import org.junit.Before;
+import org.junit.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Charsets;
 
@@ -140,14 +140,14 @@ public class ModelServerClientTest {
    public void create() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
       final JsonNode expected = jsonCodec.encode(display);
       interceptor.addRule()
-              .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=json")
-              .post()
-              .respond(JsonResponse.success(expected).toString());
+         .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=json")
+         .post()
+         .respond(JsonResponse.success(expected).toString());
       ModelServerClient client = createClient();
 
       final CompletableFuture<Response<String>> f = client.create(
-              "SuperBrewer3000.json",
-              expected.toString());
+         "SuperBrewer3000.json",
+         expected.toString());
 
       assertThat(f.get().body(), equalTo(expected.toString()));
    }
@@ -157,15 +157,15 @@ public class ModelServerClientTest {
    public void createModel() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
       final JsonNode expected = jsonCodec.encode(display);
       interceptor.addRule()
-              .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=json")
-              .post()
-              .respond(JsonResponse.success(expected).toString());
+         .url(BASE_URL + ModelServerPaths.MODEL_BASE_PATH + "?modeluri=SuperBrewer3000.json&format=json")
+         .post()
+         .respond(JsonResponse.success(expected).toString());
       ModelServerClient client = createClient();
 
       CompletableFuture<Response<EObject>> f = client.create(
-              "SuperBrewer3000.json",
-              display,
-              "json");
+         "SuperBrewer3000.json",
+         display,
+         "json");
 
       assertThat(jsonCodec.encode(f.get().body()), equalTo(expected));
    }


### PR DESCRIPTION
I have implemented the create call implementation on the client.

To prevent duplicate code I did some refactoring in ModelServerClient to combine update and create, as these are nearly the same.