### PR TITLE
Fix normalization of encoded workspace URLs

### DIFF
--- a/org.eclipse.emfcloud.modelserver.emf/src/main/java/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
+++ b/org.eclipse.emfcloud.modelserver.emf/src/main/java/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
@@ -17,6 +17,8 @@ package org.eclipse.emfcloud.modelserver.emf.configuration;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -89,17 +91,19 @@ public class ServerConfiguration {
    }
 
    private static Optional<URI> toFilePath(final String fileUrl) {
+
       try {
-         URI uri = URI.createURI(fileUrl, true);
+         String decodedUrl = URLDecoder.decode(fileUrl, "UTF-8");
+         URI uri = URI.createURI(decodedUrl, true);
          if (uri.scheme() == null) {
-            uri = URI.createFileURI(fileUrl);
+            uri = URI.createFileURI(decodedUrl);
          }
          if (uri.isRelative()) {
             URI cwd = URI.createFileURI(System.getProperty("user.dir"));
             uri = uri.resolve(ensureDirectory(cwd));
          }
          return Optional.ofNullable(uri).filter(URI::isFile);
-      } catch (NullPointerException | IllegalArgumentException e) {
+      } catch (NullPointerException | IllegalArgumentException | UnsupportedEncodingException e) {
          LOG.warn(String.format("Could not convert to filePath! ’%s’ is not a valid URL", fileUrl));
          return Optional.empty();
       }

--- a/org.eclipse.emfcloud.modelserver.emf/src/test/java/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
+++ b/org.eclipse.emfcloud.modelserver.emf/src/test/java/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeThat;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 
 import org.eclipse.emf.common.util.URI;
 import org.junit.Test;
@@ -34,6 +35,12 @@ public class ServerConfigurationTest {
    public void normalizeWorkspaceRoot() {
       serverConfiguration.setWorkspaceRoot("foo");
       assertThat(serverConfiguration.getWorkspaceRoot(), endsWith("foo/"));
+   }
+
+   @Test
+   public void normalizeWorkspaceRootEncoded() throws UnsupportedEncodingException {
+      serverConfiguration.setWorkspaceRoot("file:/c%3A/foo%20bar/");
+      assertThat(serverConfiguration.getWorkspaceRoot(), endsWith("c:/foo bar/"));
    }
 
    @Test


### PR DESCRIPTION
If using a workspace which includes spaces or other encoded chars the
ModelServer doesn't recognize the workspace and doesn't set it.

Signed-off-by: Eugen Neufeld <eneufeld@eclipsesource.com>