### PR TITLE
Improve ModelServerLauncher

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
@@ -68,6 +68,9 @@ public class ModelRepository {
    }
 
    public void initialize(final String workspaceRoot, final boolean clearResources) {
+      if (workspaceRoot==null || workspaceRoot.isEmpty()) {
+         return;
+      }
       if (clearResources) {
          resourceSet.getResources().forEach(Resource::unload);
          resourceSet.getResources().clear();

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/CLIParser.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/CLIParser.java
@@ -67,7 +67,7 @@ public final class CLIParser {
       return port;
    }
 
-   protected Optional<String> parseWorkspaceRoot() throws ParseException {
+   public Optional<String> parseWorkspaceRoot() throws ParseException {
       String rootArg = cmd.getOptionValue("r");
       if (rootArg != null) {
          if (!ServerConfiguration.isValidWorkspaceRoot(rootArg)) {

--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/ExampleServerLauncher.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/ExampleServerLauncher.java
@@ -15,15 +15,12 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-
 import org.eclipse.emfcloud.modelserver.emf.launch.CLIParser;
 import org.eclipse.emfcloud.modelserver.emf.launch.ModelServerLauncher;
 import org.eclipse.emfcloud.modelserver.example.util.ResourceUtil;
+
 import com.google.common.collect.Lists;
 
 public final class ExampleServerLauncher {
@@ -39,26 +36,8 @@ public final class ExampleServerLauncher {
    private ExampleServerLauncher() {}
 
    public static void main(String[] args) throws ParseException {
-      BasicConfigurator.configure();
-      try {
-         CLIParser.create(args, CLIParser.getDefaultCLIOptions());
-      } catch (UnrecognizedOptionException e) {
-         LOG.error("Unrecognized command line argument(s) used!\n");
-         CLIParser.printHelp(PROCESS_NAME, CLIParser.getDefaultCLIOptions());
-         return;
-      }
-
-      if (CLIParser.getInstance().optionExists("h")) {
-         CLIParser.getInstance().printHelp(PROCESS_NAME);
-         return;
-      }
-
-      Logger root = Logger.getRootLogger();
-      if (CLIParser.getInstance().optionExists("e")) {
-         root.setLevel(Level.ERROR);
-      } else {
-         root.setLevel(Level.INFO);
-      }
+      ModelServerLauncher.configureLogger();
+      CLIParser.create(args, CLIParser.getDefaultCLIOptions());
 
       if (!CLIParser.getInstance().optionExists("r")) {
          // No workspace root was specified, use test workspace


### PR DESCRIPTION
- Add static configuration method for logger
- Move generic CLIParserHandling from example to base launcher class
- Enable launching the modelsever without a valid modelsever root (can be passed later at runtime e.g. from theia)