### PR TITLE
Update ServerConfiguration path

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
@@ -56,7 +56,7 @@ public class ServerConfiguration {
 
       URI normalized = URIConverter.INSTANCE.normalize(workspaceRootURI);
       if (normalized.isFile()) {
-         try (Stream<Path> paths = Files.walk(Paths.get(normalized.toFileString()))) {
+         try (Stream<Path> paths = Files.walk(Paths.get(normalized.toString()))) {
             paths
                .filter(Files::isRegularFile)
                .forEach(file -> filePaths.add(file.toString()));


### PR DESCRIPTION
By using the toFileString() method, the returned string was not usable on windows as it was transformed from `c:/foo` to `c:%5Cfoo` as backslashes must be encoded.
By using the toString() method we return a valid path