### PR TITLE
Fix Path handling for Windows

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ServerController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ServerController.java
@@ -11,8 +11,9 @@
 package org.eclipse.emfcloud.modelserver.emf.common;
 
 import org.apache.log4j.Logger;
-
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+
 import com.google.inject.Inject;
 
 import io.javalin.http.Context;
@@ -31,11 +32,12 @@ public class ServerController {
 
    private final Handler configureHandler = ctx -> {
       ServerConfiguration newConf = ctx.bodyAsClass(ServerConfiguration.class);
-      String workspaceRoot = newConf.getWorkspaceRoot();
-      if (workspaceRoot != null) {
+      URI workspaceRootUri = newConf.getWorkspaceRootURI();
+      if (workspaceRootUri != null) {
+         String workspaceRoot = workspaceRootUri.toString();
          if (ServerConfiguration.isValidWorkspaceRoot(workspaceRoot)) {
             serverConfiguration.setWorkspaceRoot(workspaceRoot);
-            modelRepository.initialize(workspaceRoot, true);
+            modelRepository.initialize(newConf.getWorkspaceRootURI().toFileString(), true);
             ctx.json(JsonResponse.success());
          } else {
             handleError(ctx, 400, "The given workspaceRoot is not a valid path: " + workspaceRoot);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.URIConverter;
-
 import org.eclipse.emfcloud.modelserver.emf.launch.ModelServerLauncher;
 
 /**
@@ -43,8 +42,6 @@ public class ServerConfiguration {
 
    public void setWorkspaceRootURI(final URI uri) { this.workspaceRootURI = uri; }
 
-   public String getWorkspaceRoot() { return workspaceRootURI.toFileString(); }
-
    public void setWorkspaceRoot(final String workspaceRoot) {
       toFilePath(workspaceRoot)
          .map(ServerConfiguration::ensureDirectory)
@@ -56,7 +53,7 @@ public class ServerConfiguration {
 
       URI normalized = URIConverter.INSTANCE.normalize(workspaceRootURI);
       if (normalized.isFile()) {
-         try (Stream<Path> paths = Files.walk(Paths.get(normalized.toString()))) {
+         try (Stream<Path> paths = Files.walk(Paths.get(normalized.toFileString()))) {
             paths
                .filter(Files::isRegularFile)
                .forEach(file -> filePaths.add(file.toString()));

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
@@ -29,19 +29,19 @@ public class ServerConfigurationTest {
    @Test
    public void normalizeWorkspaceRoot() {
       serverConfiguration.setWorkspaceRoot("foo");
-      assertThat(serverConfiguration.getWorkspaceRoot(), endsWith("foo/"));
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), endsWith("foo/"));
    }
 
    @Test
    public void normalizeWorkspaceRootEncoded() throws UnsupportedEncodingException {
       serverConfiguration.setWorkspaceRoot("file:/c%3A/foo%20bar/");
-      assertThat(serverConfiguration.getWorkspaceRoot(), endsWith("c:/foo bar/"));
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), endsWith("c:/foo bar/"));
    }
 
    @Test
    public void normalizeWorkspaceRootSlashAlreadyPresent() {
       serverConfiguration.setWorkspaceRoot("foo/");
-      assertThat(serverConfiguration.getWorkspaceRoot(), endsWith("foo/"));
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), endsWith("foo/"));
    }
 
    @Test
@@ -49,7 +49,7 @@ public class ServerConfigurationTest {
       File cwd = getCWD();
 
       serverConfiguration.setWorkspaceRootURI(URI.createFileURI(cwd.getAbsolutePath()));
-      assertThat(serverConfiguration.getWorkspaceRoot(), is(cwd.getAbsolutePath()));
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), is(cwd.getAbsolutePath()));
    }
 
    @Test
@@ -59,7 +59,7 @@ public class ServerConfigurationTest {
       serverConfiguration.setWorkspaceRoot(".");
       URI expected = URI.createFileURI(cwd.getAbsolutePath()).appendSegment(""); // trailing slash
       assertThat(serverConfiguration.getWorkspaceRootURI(), is(expected));
-      assertThat(serverConfiguration.getWorkspaceRoot(), is(cwd.getAbsolutePath() + "/"));
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), is(cwd.getAbsolutePath() + "/"));
    }
 
    @Test


### PR DESCRIPTION
* Remove ServerConfiguration#getWorkspaceRoot() method
* Change all users to ServerConfiguration#getWorkspaceRootURI()

Signed-off-by: Eugen Neufeld <eneufeld@eclipsesource.com>