### PR TITLE
Fix #45: Ensure UI Schema directory is skipped when scanning workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ public interface ModelServerClientApiV1<A> {
 
    CompletableFuture<Response<String>> getTypeSchema(String modelUri);
 
-   CompletableFuture<Response<String>> getUISchema(String schemaname);
+   CompletableFuture<Response<String>> getUiSchema(String schemaName);
 
    CompletableFuture<Response<Boolean>> configure(ServerConfiguration configuration);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -332,7 +332,7 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
    }
 
    @Override
-   public CompletableFuture<Response<String>> getUISchema(final String schemaname) {
+   public CompletableFuture<Response<String>> getUiSchema(final String schemaname) {
       final Request request = new Request.Builder()
          .url(
             createHttpUrlBuilder(makeUrl(UI_SCHEMA))

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -349,7 +349,8 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
    public CompletableFuture<Response<Boolean>> configure(final ServerConfiguration configuration) {
 
       ObjectNode config = Json.object(
-         Json.prop("workspaceRoot", Json.text(configuration.getWorkspaceRoot())));
+         Json.prop("workspaceRoot", Json.text(configuration.getWorkspaceRoot())),
+         Json.prop("uiSchemaFolder", Json.text(configuration.getUiSchemaFolder())));
 
       final Request request = new Request.Builder()
          .url(makeUrl(SERVER_CONFIGURE))

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
@@ -46,7 +46,7 @@ public interface ModelServerClientApiV1<A> {
 
    CompletableFuture<Response<String>> getTypeSchema(String modelUri);
 
-   CompletableFuture<Response<String>> getUISchema(String schemaname);
+   CompletableFuture<Response<String>> getUiSchema(String schemaName);
 
    CompletableFuture<Response<Boolean>> configure(ServerConfiguration configuration);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ServerConfiguration.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ServerConfiguration.java
@@ -15,4 +15,14 @@ public interface ServerConfiguration {
    String getWorkspaceRoot();
 
    String getUiSchemaFolder();
+
+   static ServerConfiguration create(final String workspaceRoot, final String uiSchemaFolder) {
+      return new ServerConfiguration() {
+         @Override
+         public String getWorkspaceRoot() { return workspaceRoot; }
+
+         @Override
+         public String getUiSchemaFolder() { return uiSchemaFolder; }
+      };
+   }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ServerConfiguration.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ServerConfiguration.java
@@ -14,4 +14,5 @@ public interface ServerConfiguration {
 
    String getWorkspaceRoot();
 
+   String getUiSchemaFolder();
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
@@ -104,9 +104,7 @@ public class ModelRepository {
    }
 
    protected boolean isSourceDirectory(final File file) {
-      System.out.println("isSource[" + file.getAbsolutePath() + "] " + file.isDirectory() + " - "
-         + (!this.serverConfiguration.isUISchemaFolder(file.getAbsolutePath())));
-      return file.isDirectory() && !this.serverConfiguration.isUISchemaFolder(file.getAbsolutePath());
+      return file.isDirectory() && !this.serverConfiguration.isUiSchemaFolder(file.getAbsolutePath());
    }
 
    protected boolean hasModel(final String modeluri) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
@@ -66,25 +66,34 @@ public class ModelRepository {
       this.domain = new AdapterFactoryEditingDomain(adapterFactory, new BasicCommandStack(), resourceSet);
       this.serverConfiguration = serverConfiguration;
       this.resourceManager = resourceManager;
-      initialize(serverConfiguration.getWorkspaceRootURI().toFileString(), true);
+      initialize();
    }
 
-   public void initialize(final String workspaceRoot, final boolean clearResources) {
-      if (workspaceRoot == null || workspaceRoot.isEmpty()) {
-         return;
-      }
-      if (clearResources) {
+   public void initialize() {
+      String workspacePath = this.serverConfiguration.getWorkspaceRootURI().toFileString();
+      if (workspacePath != null) {
          resourceSet.getResources().forEach(Resource::unload);
          resourceSet.getResources().clear();
+         loadSourceResources(workspacePath);
+         removeErroneousResources();
       }
-      File workspace = new File(workspaceRoot);
-      for (File file : workspace.listFiles()) {
-         if (file.isDirectory()) {
-            initialize(file.getAbsolutePath(), false);
-         } else {
+   }
+
+   protected void loadSourceResources(final String directoryPath) {
+      if (directoryPath == null || directoryPath.isEmpty()) {
+         return;
+      }
+      File directory = new File(directoryPath);
+      for (File file : directory.listFiles()) {
+         if (isSourceDirectory(file)) {
+            loadSourceResources(file.getAbsolutePath());
+         } else if (file.isFile()) {
             resourceManager.loadResource(createURI(file.getAbsolutePath()), resourceSet);
          }
       }
+   }
+
+   protected void removeErroneousResources() {
       // any resources loaded with errors are probably not resources in the first place
       final List<Resource> resourcesWithErrors = resourceSet.getResources().stream()
          .filter(resource -> !resource.getErrors().isEmpty())
@@ -94,7 +103,13 @@ public class ModelRepository {
       }
    }
 
-   boolean hasModel(final String modeluri) {
+   protected boolean isSourceDirectory(final File file) {
+      System.out.println("isSource[" + file.getAbsolutePath() + "] " + file.isDirectory() + " - "
+         + (!this.serverConfiguration.isUISchemaFolder(file.getAbsolutePath())));
+      return file.isDirectory() && !this.serverConfiguration.isUISchemaFolder(file.getAbsolutePath());
+   }
+
+   protected boolean hasModel(final String modeluri) {
       final URI uri = createURI(modeluri);
       return resourceSet.getResource(uri, false) != null;
    }
@@ -166,7 +181,11 @@ public class ModelRepository {
       }
       LinkedHashMap<URI, EObject> models = new LinkedHashMap<>();
       resources.forEach(resource -> {
-         models.put(resource.getURI(), resource.getContents().get(0));
+         if (!resource.getContents().isEmpty()) {
+            models.put(resource.getURI(), resource.getContents().get(0));
+         } else {
+            LOG.warn("Could not retrieve empty resource with URI: " + resource.getURI());
+         }
       });
       return models;
    }
@@ -228,10 +247,8 @@ public class ModelRepository {
    ResourceSet getResourceSet() { return resourceSet; }
 
    private URI createURI(final String modeluri) {
-      if (modeluri.startsWith("file:")) {
-         return URI.createURI(modeluri, true);
-      }
-
-      return URI.createFileURI(modeluri);
+      return modeluri.startsWith("file:")
+         ? URI.createURI(modeluri, true)
+         : URI.createFileURI(modeluri);
    }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRouting.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRouting.java
@@ -137,7 +137,7 @@ public class ModelServerRouting extends Routing {
             get(ModelServerPaths.UI_SCHEMA, ctx -> {
                getQueryParam(ctx.queryParamMap(), "schemaname")
                   .ifPresentOrElse(
-                     param -> getController(SchemaController.class).getUISchema(ctx, param),
+                     param -> getController(SchemaController.class).getUiSchema(ctx, param),
                      () -> handleHttpError(ctx, 400, "Missing parameter 'schemaname'!"));
             });
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaController.java
@@ -39,8 +39,8 @@ public class SchemaController {
          });
    }
 
-   public void getUISchema(final Context ctx, final String schemaname) {
-      this.schemaRepository.loadUISchema(schemaname).ifPresentOrElse(
+   public void getUiSchema(final Context ctx, final String schemaname) {
+      this.schemaRepository.loadUiSchema(schemaname).ifPresentOrElse(
          jsonNode -> ctx.json(JsonResponse.success(jsonNode)),
          () -> {
             ctx.status(404);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepository.java
@@ -35,7 +35,7 @@ public class SchemaRepository {
 
    @Inject
    public SchemaRepository(final ServerConfiguration serverConfiguration) {
-      this.schemaRepositoryPath = serverConfiguration.getUISchemaFolderURI();
+      this.schemaRepositoryPath = serverConfiguration.getUiSchemaFolderURI();
    }
 
    public Optional<JsonNode> loadUISchema(final String schemaname) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepository.java
@@ -38,7 +38,7 @@ public class SchemaRepository {
       this.schemaRepositoryPath = serverConfiguration.getUiSchemaFolderURI();
    }
 
-   public Optional<JsonNode> loadUISchema(final String schemaname) {
+   public Optional<JsonNode> loadUiSchema(final String schemaname) {
       String schemaFilePath = this.schemaRepositoryPath.toFileString().concat(schemaname + ".json");
       ObjectMapper mapper = new ObjectMapper();
       JsonNode jsonNode = null;

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
@@ -59,7 +59,7 @@ public class ServerConfiguration {
          .ifPresent(uri -> setUiSchemaFolderURI(uri));
    }
 
-   public boolean isUISchemaFolder(final String folder) {
+   public boolean isUiSchemaFolder(final String folder) {
       return toFilePath(folder).map(getUiSchemaFolderURI()::equals).orElse(false);
    }
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfiguration.java
@@ -49,14 +49,18 @@ public class ServerConfiguration {
          .ifPresent(uri -> setWorkspaceRootURI(uri));
    }
 
-   public URI getUISchemaFolderURI() { return this.uiSchemaFolderURI; }
+   public URI getUiSchemaFolderURI() { return this.uiSchemaFolderURI; }
 
-   public void setUISchemaFolderURI(final URI uri) { this.uiSchemaFolderURI = uri; }
+   public void setUiSchemaFolderURI(final URI uri) { this.uiSchemaFolderURI = uri; }
 
-   public void setUISchemaFolder(final String uiSchemaFolder) {
+   public void setUiSchemaFolder(final String uiSchemaFolder) {
       toFilePath(uiSchemaFolder)
          .map(ServerConfiguration::ensureDirectory)
-         .ifPresent(uri -> setUISchemaFolderURI(uri));
+         .ifPresent(uri -> setUiSchemaFolderURI(uri));
+   }
+
+   public boolean isUISchemaFolder(final String folder) {
+      return toFilePath(folder).map(getUiSchemaFolderURI()::equals).orElse(false);
    }
 
    public Set<String> getWorkspaceEntries() {
@@ -85,6 +89,12 @@ public class ServerConfiguration {
 
    public void setServerPort(final int serverPort) { this.serverPort = serverPort; }
 
+   @Override
+   public String toString() {
+      return "ServerConfiguration [workspaceRootURI=" + workspaceRootURI + ", uiSchemaFolderURI=" + uiSchemaFolderURI
+         + ", serverPort=" + serverPort + "]";
+   }
+
    public static boolean isValidFileURI(final String fileUrl) {
       return toFilePath(fileUrl).map(uri -> new File(uri.toFileString()).exists()).orElse(false);
    }
@@ -99,7 +109,7 @@ public class ServerConfiguration {
          String decodedUrl = URLDecoder.decode(fileUrl, "UTF-8");
          URI uri = URI.createURI(decodedUrl, true);
          if (uri.scheme() == null) {
-            uri = URI.createFileURI(decodedUrl);
+            uri = ensureDirectory(URI.createFileURI(decodedUrl));
          }
          if (uri.isRelative()) {
             URI cwd = URI.createFileURI(System.getProperty("user.dir"));

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/CLIParser.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/CLIParser.java
@@ -81,7 +81,7 @@ public final class CLIParser {
       return Optional.empty();
    }
 
-   public Optional<String> parseUISchemaFolder() throws ParseException {
+   public Optional<String> parseUiSchemaFolder() throws ParseException {
       String uiSchemaFolderArg = cmd.getOptionValue("u");
       if (uiSchemaFolderArg != null) {
          if (!ServerConfiguration.isValidFileURI(uiSchemaFolderArg)) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/ModelServerLauncher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/ModelServerLauncher.java
@@ -95,7 +95,7 @@ public class ModelServerLauncher {
          }
          configuration.setServerPort(parser.parsePort());
          parser.parseWorkspaceRoot().ifPresent(configuration::setWorkspaceRoot);
-         parser.parseUISchemaFolder().ifPresent(configuration::setUISchemaFolder);
+         parser.parseUiSchemaFolder().ifPresent(configuration::setUiSchemaFolder);
          return true;
       } catch (UnrecognizedOptionException e) {
          LOG.error("Unrecognized command line argument(s) used!\n");

--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/ExampleServerLauncher.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/ExampleServerLauncher.java
@@ -87,34 +87,34 @@ public final class ExampleServerLauncher {
          new File(workspaceRoot, COFFEE_TEST_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_ROOT + "/" + JSON_TEST_FILE,
          new File(workspaceRoot, JSON_TEST_FILE));
-      result &= setupTempUISchemaTestWorkspace(new File(workspaceRoot + "/" + UISCHEMA_FOLDER + "/"), result);
+      result &= setupTempUiSchemaTestWorkspace(new File(workspaceRoot + "/" + UISCHEMA_FOLDER + "/"), result);
       return result;
    }
 
    @SuppressWarnings("checkstyle:CyclomaticComplexity")
-   private static boolean setupTempUISchemaTestWorkspace(final File workspaceUISchemaRoot, boolean result) {
+   private static boolean setupTempUiSchemaTestWorkspace(final File workspaceUiSchemaRoot, boolean result) {
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_AUTOMATICTASK_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_AUTOMATICTASK_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_AUTOMATICTASK_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_BREWINGUNIT_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_BREWINGUNIT_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_BREWINGUNIT_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_CONTROLUNIT_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_CONTROLUNIT_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_CONTROLUNIT_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_DECISION_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_DECISION_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_DECISION_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_DIPTRAY_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_DIPTRAY_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_DIPTRAY_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_FLOW_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_FLOW_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_FLOW_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_MACHINE_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_MACHINE_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_MACHINE_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_MANUALTASK_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_MANUALTASK_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_MANUALTASK_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_MERGE_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_MERGE_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_MERGE_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_WATERTANK_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_WATERTANK_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_WATERTANK_FILE));
       result &= result && ResourceUtil.copyFromResource(WORKSPACE_UISCHEMA_FOLDER + "/" + UISCHEMA_WEIGHTEDFLOW_FILE,
-         new File(workspaceUISchemaRoot, UISCHEMA_WEIGHTEDFLOW_FILE));
+         new File(workspaceUiSchemaRoot, UISCHEMA_WEIGHTEDFLOW_FILE));
       return result;
    }
 

--- a/tests/org.eclipse.emfcloud.modelserver.client.tests/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.client.tests/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
@@ -421,7 +421,13 @@ public class ModelServerClientTest {
          .respond(JsonResponse.success().toString());
       ModelServerClient client = createClient();
 
-      final CompletableFuture<Response<Boolean>> f = client.configure(() -> "/home/user/workspace");
+      final CompletableFuture<Response<Boolean>> f = client.configure(new ServerConfiguration() {
+         @Override
+         public String getWorkspaceRoot() { return "/home/user/workspace"; }
+
+         @Override
+         public String getUiSchemaFolder() { return "/home/user/workspace/.ui-schemas"; }
+      });
 
       assertThat(f.get().body(), equalTo(true));
    }

--- a/tests/org.eclipse.emfcloud.modelserver.client.tests/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.client.tests/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
@@ -368,7 +368,7 @@ public class ModelServerClientTest {
 
    @Test
    @SuppressWarnings({ "checkstyle:ThrowsCount" })
-   public void getUISchema() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
+   public void getUiSchema() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
       final JsonNode expected = JsonCodec.encode(Json.object(Json.prop("type", Json.text("object"))));
       String uiSchemaUrl = baseHttpUrlBuilder
          .addPathSegment(ModelServerPaths.UI_SCHEMA)
@@ -380,7 +380,7 @@ public class ModelServerClientTest {
          .respond(JsonResponse.success(expected).toString());
       ModelServerClient client = createClient();
 
-      final CompletableFuture<Response<String>> f = client.getUISchema("controlunit");
+      final CompletableFuture<Response<String>> f = client.getUiSchema("controlunit");
 
       assertThat(f.get().body(), equalTo(expected.toString()));
    }
@@ -421,13 +421,9 @@ public class ModelServerClientTest {
          .respond(JsonResponse.success().toString());
       ModelServerClient client = createClient();
 
-      final CompletableFuture<Response<Boolean>> f = client.configure(new ServerConfiguration() {
-         @Override
-         public String getWorkspaceRoot() { return "/home/user/workspace"; }
-
-         @Override
-         public String getUiSchemaFolder() { return "/home/user/workspace/.ui-schemas"; }
-      });
+      ServerConfiguration serverConfiguration = ServerConfiguration.create("/home/user/workspace",
+         "/home/user/workspace/.ui-schemas");
+      final CompletableFuture<Response<Boolean>> f = client.configure(serverConfiguration);
 
       assertThat(f.get().body(), equalTo(true));
    }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaControllerTest.java
@@ -100,7 +100,7 @@ public class SchemaControllerTest {
    }
 
    @Test
-   public void getUISchema_schemaAvailable() {
+   public void getUiSchema_schemaAvailable() {
       final JsonNode machineUiSchema = Json.object(
          prop("type", Json.text("VerticalLayout")),
          prop("elements", Json.array(
@@ -112,9 +112,9 @@ public class SchemaControllerTest {
                prop("label", Json.text("Name")),
                prop("scope", Json.text("#/properties/name"))))));
 
-      when(schemaRepository.loadUISchema("machine")).thenReturn(Optional.of(machineUiSchema));
+      when(schemaRepository.loadUiSchema("machine")).thenReturn(Optional.of(machineUiSchema));
 
-      schemaController.getUISchema(context, "machine");
+      schemaController.getUiSchema(context, "machine");
 
       JsonNode expectedResponse = Json.object(
          prop("type", Json.text("success")),
@@ -124,11 +124,11 @@ public class SchemaControllerTest {
    }
 
    @Test
-   public void getUISchema_schemaUnavailable() {
+   public void getUiSchema_schemaUnavailable() {
       when(context.queryParam("schemaname")).thenReturn("brewing");
-      when(schemaRepository.loadUISchema("brewing")).thenReturn(Optional.empty());
+      when(schemaRepository.loadUiSchema("brewing")).thenReturn(Optional.empty());
 
-      schemaController.getUISchema(context, "brewing");
+      schemaController.getUiSchema(context, "brewing");
 
       String expectedErrorMsg = "UI schema 'brewing' not found!";
       JsonNode expectedResponse = Json.object(

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepositoryTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepositoryTest.java
@@ -48,8 +48,8 @@ public class SchemaRepositoryTest {
    }
 
    @Test
-   public void loadUISchema_schemaAvailable() throws IOException {
-      final JsonNode expectedUISchema = Json.object(
+   public void loadUiSchema_schemaAvailable() throws IOException {
+      final JsonNode expectedUiSchema = Json.object(
          prop("type", Json.text("VerticalLayout")),
          prop("elements", Json.array(
             Json.object(
@@ -60,15 +60,15 @@ public class SchemaRepositoryTest {
                prop("label", Json.text("Name")),
                prop("scope", Json.text("#/properties/name"))))));
 
-      Optional<JsonNode> actualUISchema = schemaRepository.loadUISchema("machine");
+      Optional<JsonNode> actualUiSchema = schemaRepository.loadUiSchema("machine");
 
-      assertTrue(actualUISchema.isPresent());
-      assertEquals(expectedUISchema, actualUISchema.get());
+      assertTrue(actualUiSchema.isPresent());
+      assertEquals(expectedUiSchema, actualUiSchema.get());
    }
 
    @Test
-   public void loadUISchema_schemaUnvailable() throws IOException {
-      assertTrue(schemaRepository.loadUISchema("machine2").isEmpty());
+   public void loadUiSchema_schemaUnvailable() throws IOException {
+      assertTrue(schemaRepository.loadUiSchema("machine2").isEmpty());
    }
 
    //

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepositoryTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SchemaRepositoryTest.java
@@ -42,7 +42,7 @@ public class SchemaRepositoryTest {
    @Before
    public void before() {
       serverConfiguration = mock(ServerConfiguration.class);
-      when(serverConfiguration.getUISchemaFolderURI())
+      when(serverConfiguration.getUiSchemaFolderURI())
          .thenReturn(URI.createFileURI(getCWD().getAbsolutePath() + "/ui-schemas/"));
       schemaRepository = new SchemaRepository(serverConfiguration);
    }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
@@ -66,10 +66,10 @@ public class ServerConfigurationTest {
    public void getUISchemaFolder() {
       File cwd = getCWD();
 
-      serverConfiguration.setUISchemaFolder("./ui-schema-folder");
+      serverConfiguration.setUiSchemaFolder("./ui-schema-folder");
       URI expected = URI.createFileURI(cwd.getAbsolutePath() + "/ui-schema-folder").appendSegment(""); // trailing slash
-      assertThat(serverConfiguration.getUISchemaFolderURI(), is(expected));
-      assertThat(serverConfiguration.getUISchemaFolderURI().toFileString(),
+      assertThat(serverConfiguration.getUiSchemaFolderURI(), is(expected));
+      assertThat(serverConfiguration.getUiSchemaFolderURI().toFileString(),
          is(cwd.getAbsolutePath() + "/ui-schema-folder/"));
    }
 

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/ServerConfigurationTest.java
@@ -63,7 +63,7 @@ public class ServerConfigurationTest {
    }
 
    @Test
-   public void getUISchemaFolder() {
+   public void getUiSchemaFolder() {
       File cwd = getCWD();
 
       serverConfiguration.setUiSchemaFolder("./ui-schema-folder");
@@ -71,6 +71,22 @@ public class ServerConfigurationTest {
       assertThat(serverConfiguration.getUiSchemaFolderURI(), is(expected));
       assertThat(serverConfiguration.getUiSchemaFolderURI().toFileString(),
          is(cwd.getAbsolutePath() + "/ui-schema-folder/"));
+   }
+
+   @Test
+   public void isUiSchemaFolder() {
+      File cwd = getCWD();
+
+      serverConfiguration.setUiSchemaFolder("./ui-schema-folder");
+      String expected = cwd.getAbsolutePath() + "/ui-schema-folder";
+
+      // true with or without trailing slash
+      assertThat(serverConfiguration.isUiSchemaFolder(expected), is(true));
+      assertThat(serverConfiguration.isUiSchemaFolder(expected + "/"), is(true));
+
+      // false for: parent, child
+      assertThat(serverConfiguration.isUiSchemaFolder(cwd.getAbsolutePath()), is(false));
+      assertThat(serverConfiguration.isUiSchemaFolder(expected + "test/"), is(false));
    }
 
    @Test


### PR DESCRIPTION
- Make sure the UI schema directory is part of the server configuration
- Skip UI schema directory resources when loading workspace resources
- Guard against NPE by checking resource content in 'getAllModels'

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>