### PR TITLE
Add necessary dependencies to modelserver.lib bundle

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.lib/.classpath
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/.classpath
@@ -6,7 +6,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
 	<classpathentry exported="true" kind="lib" path="lib/annotations-13.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/kotlin-stdlib-1.3.40.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/kotlin-stdlib-common-1.3.40.jar"/>

--- a/bundles/org.eclipse.emfcloud.modelserver.lib/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/META-INF/MANIFEST.MF
@@ -64,3 +64,15 @@ Export-Package: io.javalin,
  org.eclipse.jetty.websocket.servlet,
  org.intellij.lang.annotations,
  org.jetbrains.annotations
+Import-Package: javax.servlet;version="3.1.0",
+ javax.servlet.http;version="3.1.0",
+ org.slf4j;version="1.7.2"
+Require-Bundle: org.eclipse.jetty.util;bundle-version="9.4.24",
+ org.eclipse.jetty.server;bundle-version="9.4.24",
+ org.eclipse.jetty.servlet;bundle-version="9.4.24",
+ org.eclipse.jetty.websocket.server;bundle-version="9.4.24",
+ org.eclipse.jetty.websocket.api;bundle-version="9.4.24",
+ org.eclipse.jetty.websocket.common;bundle-version="9.4.24",
+ org.eclipse.jetty.websocket.servlet;bundle-version="9.4.24",
+ com.fasterxml.jackson.core.jackson-databind;bundle-version="2.9.0",
+ com.fasterxml.jackson.core.jackson-core;bundle-version="2.9.0"

--- a/bundles/org.eclipse.emfcloud.modelserver.lib/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/META-INF/MANIFEST.MF
@@ -65,8 +65,7 @@ Export-Package: io.javalin,
  org.intellij.lang.annotations,
  org.jetbrains.annotations
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0",
- org.slf4j;version="1.7.2"
+ javax.servlet.http;version="3.1.0"
 Require-Bundle: org.eclipse.jetty.util;bundle-version="9.4.24",
  org.eclipse.jetty.server;bundle-version="9.4.24",
  org.eclipse.jetty.servlet;bundle-version="9.4.24",
@@ -75,4 +74,5 @@ Require-Bundle: org.eclipse.jetty.util;bundle-version="9.4.24",
  org.eclipse.jetty.websocket.common;bundle-version="9.4.24",
  org.eclipse.jetty.websocket.servlet;bundle-version="9.4.24",
  com.fasterxml.jackson.core.jackson-databind;bundle-version="2.9.0",
- com.fasterxml.jackson.core.jackson-core;bundle-version="2.9.0"
+ com.fasterxml.jackson.core.jackson-core;bundle-version="2.9.0",
+ org.slf4j.api;bundle-version="1.7.10"

--- a/bundles/org.eclipse.emfcloud.modelserver.lib/build.properties
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/build.properties
@@ -1,5 +1,3 @@
-source.. = src/
-output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                lib/annotations-13.0.jar,\

--- a/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.target
+++ b/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2019-12 - Release" sequenceNumber="1604415831">
+<target name="2019-12 - Release" sequenceNumber="1605191547">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.platform.feature.group" version="4.14.0.v20191210-0610"/>
@@ -26,6 +26,7 @@
       <unit id="net.bytebuddy.byte-buddy-agent" version="1.9.0.v20181106-1534"/>
       <unit id="org.objenesis" version="2.6.0.v20180420-1519"/>
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.target
+++ b/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2019-12 - Release" sequenceNumber="1580139818">
+<target name="2019-12 - Release" sequenceNumber="1604415831">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.platform.feature.group" version="4.14.0.v20191210-0610"/>
@@ -31,6 +31,10 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.emfjson.jackson" version="0.0.0"/>
       <repository location="http://ghillairet.github.io/p2"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.jetty.websocket.server" version="0.0.0"/>
+      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.tpd
+++ b/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.tpd
@@ -29,3 +29,6 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R201911262232
 location "http://ghillairet.github.io/p2" {
 	org.emfjson.jackson lazy
 }
+location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/" {
+	org.eclipse.jetty.websocket.server lazy
+}

--- a/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.tpd
+++ b/releng/org.eclipse.emfcloud.modelserver.releng.target/r2019-12.tpd
@@ -23,6 +23,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R201911262232
 	net.bytebuddy.byte-buddy-agent [1.9.0,2.0.0)
 	org.objenesis [2.6.0,3.0.0)
 	org.hamcrest [1.1.0,2.0.0)
+	org.slf4j.api [1.7.10,2.0.0)
 }
 
 // EMF-JSON


### PR DESCRIPTION
When trying to use the org.eclipse.emfcloud.modelserver.lib as a bundle,
the libraries inside the bundle can't resolve necessary dependencies, eg
slf4j.
By adding the dependencies explicitly to the MANIFEST, this issue is
resolved.

Signed-off-by: Eugen Neufeld <eneufeld@eclipsesource.com>