### PR TITLE
Ignore org.eclipse.emfcloud.modelserver.lib for source-feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
 									<excludes>
 										<plugin id="org.apache.batik.pdf" />
 										<plugin id="org.eclipse.wst.common.project.facet.core" />
+										<plugin id="org.eclipse.emfcloud.modelserver.lib" />
 									</excludes>
 								</configuration>
 							</execution>


### PR DESCRIPTION
- This plug-in repackages some external Jars, and doesn't actually provide any source code

Note: the PR build doesn't include the update site; so we missed this issue in the previous PR (#47). To test this, we need to run the build with:

`mvn clean verify -Pp2 -Pp2-release`

And check that `org.eclipse.emfcloud.modelserver.releng.p2` is succesfully built:

```
[INFO] org.eclipse.emfcloud.modelserver.feature ........... SUCCESS [  0.179 s]
[INFO] org.eclipse.emfcloud.modelserver.releng.p2 ......... SUCCESS [01:33 min]
```