### PR TITLE
Improve WebSocket connections regarding timeout and keepAlive messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,11 @@ public interface ModelServerClientApiV1<A> {
 
    CompletableFuture<Response<Boolean>> edit(String modelUri, CCommand command, String format);
 
-   void subscribe(String modelUri, SubscriptionListener subscriptionListener, String format);
+   void subscribe(String modelUri, SubscriptionListener subscriptionListener);
+
+   void subscribe(String modelUri, SubscriptionListener subscriptionListener, long timeout);
+
+   boolean send(String modelUri, String message);
 
    boolean unsubscribe(String modelUri);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -485,7 +485,7 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
                   .toString()))
          .build();
 
-      subscribe(modelUri, subscriptionListener, request);
+      doSubscribe(modelUri, subscriptionListener, request);
    }
 
    @Override
@@ -501,10 +501,10 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
                   .toString()))
          .build();
 
-      subscribe(modelUri, subscriptionListener, request);
+      doSubscribe(modelUri, subscriptionListener, request);
    }
 
-   private void subscribe(final String modelUri, final SubscriptionListener subscriptionListener,
+   private void doSubscribe(final String modelUri, final SubscriptionListener subscriptionListener,
       final Request request) {
       @SuppressWarnings({ "checkstyle:AnonInnerLength" })
       final WebSocket socket = client.newWebSocket(request, new WebSocketListener() {

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -475,18 +475,37 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
    }
 
    @Override
-   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener, final String format) {
-      String checkedFormat = checkedFormat(format);
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener) {
       Request request = new Request.Builder()
          .url(
             makeWsUrl(
                createHttpUrlBuilder(makeUrl(SUBSCRIPTION))
                   .addQueryParameter("modeluri", modelUri)
-                  .addQueryParameter("format", checkedFormat)
                   .build()
                   .toString()))
          .build();
 
+      subscribe(modelUri, subscriptionListener, request);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener,
+      final long timeout) {
+      Request request = new Request.Builder()
+         .url(
+            makeWsUrl(
+               createHttpUrlBuilder(makeUrl(SUBSCRIPTION))
+                  .addQueryParameter("modeluri", modelUri)
+                  .addQueryParameter("timeout", String.valueOf(timeout))
+                  .build()
+                  .toString()))
+         .build();
+
+      subscribe(modelUri, subscriptionListener, request);
+   }
+
+   private void subscribe(final String modelUri, final SubscriptionListener subscriptionListener,
+      final Request request) {
       @SuppressWarnings({ "checkstyle:AnonInnerLength" })
       final WebSocket socket = client.newWebSocket(request, new WebSocketListener() {
          @Override
@@ -523,6 +542,15 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
          }
       });
       openSockets.put(modelUri, socket);
+   }
+
+   @Override
+   public boolean send(final String modelUri, final String message) {
+      final WebSocket webSocket = openSockets.get(modelUri);
+      if (webSocket != null) {
+         return webSocket.send(message);
+      }
+      return false;
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
@@ -62,7 +62,11 @@ public interface ModelServerClientApiV1<A> {
 
    CompletableFuture<Response<Boolean>> edit(String modelUri, CCommand command, String format);
 
-   void subscribe(String modelUri, SubscriptionListener subscriptionListener, String format);
+   void subscribe(String modelUri, SubscriptionListener subscriptionListener);
+
+   void subscribe(String modelUri, SubscriptionListener subscriptionListener, long timeout);
+
+   boolean send(String modelUri, String message);
 
    boolean unsubscribe(String modelUri);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/JsonResponse.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/JsonResponse.java
@@ -10,9 +10,9 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
+import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 import org.jetbrains.annotations.Nullable;
 
-import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -78,5 +78,9 @@ public final class JsonResponse {
 
    public static JsonNode dirtyState(final Boolean isDirty) {
       return Json.merge(type(JsonResponseType.DIRTYSTATE), data(isDirty));
+   }
+
+   public static JsonNode keepAlive(final String message) {
+      return Json.merge(type(JsonResponseType.KEEPALIVE), data(message));
    }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/JsonResponseType.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/JsonResponseType.java
@@ -16,7 +16,8 @@ public enum JsonResponseType {
    ERROR("error"),
    FULLUPDATE("fullUpdate"),
    INCREMENTALUPDATE("incrementalUpdate"),
-   DIRTYSTATE("dirtyState");
+   DIRTYSTATE("dirtyState"),
+   KEEPALIVE("keepAlive");
 
    private String typeString;
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
@@ -12,28 +12,30 @@ package org.eclipse.emfcloud.modelserver.emf.common;
 
 import static java.util.stream.Collectors.toSet;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
-
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
+import org.jetbrains.annotations.Nullable;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
+import io.javalin.plugin.json.JavalinJackson;
 import io.javalin.websocket.WsContext;
 import io.javalin.websocket.WsHandler;
+import io.javalin.websocket.WsMessageContext;
 
 public class SessionController extends WsHandler {
 
@@ -46,16 +48,18 @@ public class SessionController extends WsHandler {
 
    private final Codecs encoder;
 
-   // Primarily for testability because the final session field cannot be mocked
-   private Predicate<? super WsContext> isOpenPredicate = ctx -> ctx.session.isOpen();
-
    public SessionController() {
       this.encoder = new Codecs();
    }
 
    public boolean subscribe(final WsContext ctx, final String modeluri) {
+      return this.subscribe(ctx, modeluri, ctx.session.getIdleTimeout()); // returns default timeout of 300000ms
+   }
+
+   public boolean subscribe(final WsContext ctx, final String modeluri, final long timeout) {
       if (this.modelRepository.hasModel(modeluri)) {
          modelUrisToClients.computeIfAbsent(modeluri, clients -> ConcurrentHashMap.newKeySet()).add(ctx);
+         ctx.session.setIdleTimeout(timeout);
          ctx.send(JsonResponse.success(ctx.getSessionId()));
          return true;
       }
@@ -79,6 +83,39 @@ public class SessionController extends WsHandler {
       }
 
       return true;
+   }
+
+   public boolean handleMessage(final WsMessageContext ctx) {
+      if (!this.isClientSubscribed(ctx)) {
+         return false;
+      }
+
+      if (readMessageType(ctx).equals(JsonResponseType.KEEPALIVE.toString())) {
+         ctx.send(JsonResponse.keepAlive(ctx.getSessionId() + " stayin' alive!"));
+         return true;
+      }
+
+      return false;
+   }
+
+   private String readMessageType(final WsMessageContext ctx) {
+      try {
+         JsonNode json = JavalinJackson.getObjectMapper().readTree(ctx.message());
+         if (!json.has("type")) {
+            handleError(ctx, "Empty JSON");
+            return "";
+         }
+         JsonNode jsonTypeNode = json.get("type");
+         String jsonType = !jsonTypeNode.asText().isEmpty() ? jsonTypeNode.asText() : jsonTypeNode.toString();
+         if (jsonType.equals("{}")) {
+            handleError(ctx, "Empty JSON");
+            return "";
+         }
+         return jsonType;
+      } catch (IOException e) {
+         handleError(ctx, "Invalid JSON");
+      }
+      return "";
    }
 
    public void modelChanged(final String modeluri) {
@@ -109,7 +146,7 @@ public class SessionController extends WsHandler {
 
    private Stream<WsContext> getOpenSessions(final String modeluri) {
       return modelUrisToClients.getOrDefault(modeluri, Collections.emptySet()).stream()
-         .filter(isOpenPredicate);
+         .filter(ctx -> ctx.session.isOpen());
    }
 
    private void broadcastFullUpdate(final String modeluri, @Nullable final EObject updatedModel) {
@@ -158,8 +195,9 @@ public class SessionController extends WsHandler {
          .isEmpty();
    }
 
-   @TestOnly
-   void setIsOnlyPredicate(final Predicate<? super WsContext> isOpen) {
-      this.isOpenPredicate = isOpen == null ? ctx -> ctx.session.isOpen() : isOpen;
+   private void handleError(final WsContext ctx, final String errorMsg) {
+      LOG.error(errorMsg);
+      ctx.send(JsonResponse.error(errorMsg));
    }
+
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
@@ -53,7 +53,7 @@ public class SessionController extends WsHandler {
    }
 
    public boolean subscribe(final WsContext ctx, final String modeluri) {
-      return this.subscribe(ctx, modeluri, ctx.session.getIdleTimeout()); // returns default timeout of 300000ms
+      return this.subscribe(ctx, modeluri, -1); // Do not set an IdleTimeout, keep socket open until client disconnects
    }
 
    public boolean subscribe(final WsContext ctx, final String modeluri, final long timeout) {


### PR DESCRIPTION
- Allow clients to set idle timeout on subscription (default is 300000ms)
- Handle ws messages (type keepAlive) to enable clients to prolong connection independently
- Extend SessionControllerTest
 - Remove TestOnly predicate in SessionController and mock fields directly
- Remove format argument in subscribe(..) in ModelServerClientAPI as it was never used or implemented (may open an issue for that though)

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>

Please also see https://github.com/eclipse-emfcloud/emfcloud-modelserver-theia/pull/23