### PR TITLE
Fix broadcasting of Undo/Redo updates especially for XMI listeners

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -29,10 +29,12 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EMFJsonConverter;
+import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
@@ -254,12 +256,40 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    }
 
    @Override
-   public Command undo(final String modeluri) {
+   public CCommand getUndoCommand(final String modeluri) {
+      Command undoCommand = getEditingDomain(getResourceSet(modeluri)).getUndoCommand();
+      if (undoCommand != null) {
+         try {
+            return EcoreUtil.copy(commandCodec.encode(undoCommand));
+         } catch (EncodingException e) {
+            LOG.error("Encoding of " + undoCommand + " failed: " + e.getMessage());
+            throw new IllegalArgumentException(e);
+         }
+      }
+      return null;
+   }
+
+   @Override
+   public boolean undo(final String modeluri) {
       return getEditingDomain(getResourceSet(modeluri)).undo();
    }
 
    @Override
-   public Command redo(final String modeluri) {
+   public CCommand getRedoCommand(final String modeluri) {
+      Command redoCommand = getEditingDomain(getResourceSet(modeluri)).getRedoCommand();
+      if (redoCommand != null) {
+         try {
+            return EcoreUtil.copy(commandCodec.encode(redoCommand));
+         } catch (EncodingException e) {
+            LOG.error("Encoding of " + redoCommand + " failed: " + e.getMessage());
+            throw new IllegalArgumentException(e);
+         }
+      }
+      return null;
+   }
+
+   @Override
+   public boolean redo(final String modeluri) {
       return getEditingDomain(getResourceSet(modeluri)).redo();
    }
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -29,7 +29,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
@@ -259,12 +258,7 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    public CCommand getUndoCommand(final String modeluri) {
       Command undoCommand = getEditingDomain(getResourceSet(modeluri)).getUndoCommand();
       if (undoCommand != null) {
-         try {
-            return EcoreUtil.copy(commandCodec.encode(undoCommand));
-         } catch (EncodingException e) {
-            LOG.error("Encoding of " + undoCommand + " failed: " + e.getMessage());
-            throw new IllegalArgumentException(e);
-         }
+         return encodeCommand(undoCommand);
       }
       return null;
    }
@@ -278,14 +272,18 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    public CCommand getRedoCommand(final String modeluri) {
       Command redoCommand = getEditingDomain(getResourceSet(modeluri)).getRedoCommand();
       if (redoCommand != null) {
-         try {
-            return EcoreUtil.copy(commandCodec.encode(redoCommand));
-         } catch (EncodingException e) {
-            LOG.error("Encoding of " + redoCommand + " failed: " + e.getMessage());
-            throw new IllegalArgumentException(e);
-         }
+         return encodeCommand(redoCommand);
       }
       return null;
+   }
+
+   protected CCommand encodeCommand(final Command command) {
+      try {
+         return commandCodec.encode(command);
+      } catch (EncodingException e) {
+         LOG.error("Encoding of " + command + " failed: " + e.getMessage());
+         throw new IllegalArgumentException(e);
+      }
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.log4j.Logger;
-import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -184,37 +183,31 @@ public class ModelController {
    }
 
    public void undo(final Context ctx, final String modeluri) {
-      Command undoCommand = modelRepository.undo(modeluri);
+      CCommand undoCommand = modelRepository.getUndoCommand(modeluri);
       if (undoCommand != null) {
-         CCommand encodedCommand;
-         try {
-            encodedCommand = new DefaultCommandCodec().encode(undoCommand);
+         Map<String, JsonNode> encodings = sessionController.getCommandEncodings(modeluri, undoCommand);
+         boolean undoSuccess = modelRepository.undo(modeluri);
+         if (undoSuccess) {
             ctx.json(JsonResponse.success("Successful undo."));
-            sessionController.modelChanged(modeluri, encodedCommand);
-         } catch (EncodingException e) {
-            LOG.error("Encoding of " + undoCommand + " failed: " + e.getMessage());
-            throw new IllegalArgumentException(e);
+            sessionController.broadcastUndoRedo(modeluri, encodings);
+            return;
          }
-      } else {
-         handleWarning(ctx, 202, "Cannot undo.");
       }
+      handleWarning(ctx, 202, "Cannot undo.");
    }
 
    public void redo(final Context ctx, final String modeluri) {
-      Command redoCommand = modelRepository.redo(modeluri);
+      CCommand redoCommand = modelRepository.getRedoCommand(modeluri);
       if (redoCommand != null) {
-         CCommand encodedCommand;
-         try {
-            encodedCommand = new DefaultCommandCodec().encode(redoCommand);
+         Map<String, JsonNode> encodings = sessionController.getCommandEncodings(modeluri, redoCommand);
+         boolean redoSuccess = modelRepository.redo(modeluri);
+         if (redoSuccess) {
             ctx.json(JsonResponse.success("Successful redo."));
-            sessionController.modelChanged(modeluri, encodedCommand);
-         } catch (EncodingException e) {
-            LOG.error("Encoding of " + redoCommand + " failed: " + e.getMessage());
-            throw new IllegalArgumentException(e);
+            sessionController.broadcastUndoRedo(modeluri, encodings);
+            return;
          }
-      } else {
-         handleWarning(ctx, 202, "Cannot redo");
       }
+      handleWarning(ctx, 202, "Cannot redo");
    }
 
    public void getModelUris(final Context ctx) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
@@ -24,7 +24,6 @@ import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EMFJsonConverter;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
-import org.eclipse.emfcloud.modelserver.edit.DefaultCommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
@@ -185,6 +184,15 @@ public class ModelController {
    public void undo(final Context ctx, final String modeluri) {
       CCommand undoCommand = modelRepository.getUndoCommand(modeluri);
       if (undoCommand != null) {
+         /*
+          * In order to encode certain commands (e.g., commands that remove model elements) we need all element
+          * information,
+          * e.g., the info which element was removed before it is gone. Therefore we encode the command in all formats
+          * and provide them to the model repository which will select the correct format for each subscribed client.
+          * This means that we encode the command once for all formats beforehand. The alternative would be to encode it
+          * once per subscribed client.
+          * The same applies to the redo method below.
+          */
          Map<String, JsonNode> encodings = sessionController.getCommandEncodings(modeluri, undoCommand);
          boolean undoSuccess = modelRepository.undo(modeluri);
          if (undoSuccess) {
@@ -199,6 +207,7 @@ public class ModelController {
    public void redo(final Context ctx, final String modeluri) {
       CCommand redoCommand = modelRepository.getRedoCommand(modeluri);
       if (redoCommand != null) {
+         /* Please see comment in undo method */
          Map<String, JsonNode> encodings = sessionController.getCommandEncodings(modeluri, redoCommand);
          boolean redoSuccess = modelRepository.redo(modeluri);
          if (redoSuccess) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
-import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -145,11 +144,19 @@ public class ModelRepository {
       return modelResourceManager.getDirtyState(modeluri);
    }
 
-   public Command undo(final String modeluri) {
+   public CCommand getUndoCommand(final String modeluri) {
+      return modelResourceManager.getUndoCommand(modeluri);
+   }
+
+   public boolean undo(final String modeluri) {
       return modelResourceManager.undo(modeluri);
    }
 
-   public Command redo(final String modeluri) {
+   public CCommand getRedoCommand(final String modeluri) {
+      return modelResourceManager.getRedoCommand(modeluri);
+   }
+
+   public boolean redo(final String modeluri) {
       return modelResourceManager.redo(modeluri);
    }
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
-import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -49,9 +48,13 @@ public interface ModelResourceManager {
 
    void removeResource(String modeluri) throws IOException;
 
-   Command undo(String modeluri);
+   CCommand getUndoCommand(String modeluri);
 
-   Command redo(String modeluri);
+   boolean undo(String modeluri);
+
+   CCommand getRedoCommand(String modeluri);
+
+   boolean redo(String modeluri);
 
    boolean save(String modeluri);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerEditingDomain.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerEditingDomain.java
@@ -53,12 +53,11 @@ public class ModelServerEditingDomain extends AdapterFactoryEditingDomain {
 
    public Command getUndoCommand() {
       /*
-       * The undoCommand represents the executed command on the command stack that will be undone.
-       * The BasicCommandStack has its own internal logic on how to undo a certain command.
-       * As our clients will most likely not make use of any concept similar to a command stack, it is necessary
-       * to provide an update which holds the command to undo the previous changes as incrementalUpdate.
-       * Therefore we need to invert the command, which is currently based on the already implemented commands
-       * in the DefaultCommandCodec.
+       * As we manage the command stack locally, and our clients will most likely not make use of any concept similar to
+       * a command stack, it is necessary to provide an update which holds the command to undo the previous changes as
+       * an incrementalUpdate.
+       * In the case of an Undo we need to invert this command, which is currently based on the already implemented
+       * commands in the DefaultCommandCodec.
        */
       if (canUndo()) {
          return createInverseCommand(commandStack.getUndoCommand());
@@ -75,6 +74,11 @@ public class ModelServerEditingDomain extends AdapterFactoryEditingDomain {
    }
 
    public Command getRedoCommand() {
+      /*
+       * As we manage the command stack locally, and our clients will most likely not make use of any concept similar to
+       * a command stack, it is necessary to provide an update which holds the command to redo the previous changes as
+       * an incrementalUpdate.
+       */
       if (canRedo()) {
          return commandStack.getRedoCommand();
       }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerEditingDomain.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerEditingDomain.java
@@ -51,30 +51,42 @@ public class ModelServerEditingDomain extends AdapterFactoryEditingDomain {
       return commandStack.canRedo();
    }
 
-   public Command undo() {
-      Command undoCommand = commandStack.getUndoCommand();
+   public Command getUndoCommand() {
+      /*
+       * The undoCommand represents the executed command on the command stack that will be undone.
+       * The BasicCommandStack has its own internal logic on how to undo a certain command.
+       * As our clients will most likely not make use of any concept similar to a command stack, it is necessary
+       * to provide an update which holds the command to undo the previous changes as incrementalUpdate.
+       * Therefore we need to invert the command, which is currently based on the already implemented commands
+       * in the DefaultCommandCodec.
+       */
       if (canUndo()) {
-         commandStack.undo();
-         /*
-          * The undoCommand represents the executed command on the command stack that will be undone.
-          * The BasicCommandStack has its own internal logic on how to undo a certain command.
-          * As our clients will most likely not make use of any concept similar to a command stack, it is necessary
-          * to provide an update which holds the command to undo the previous changes as incrementalUpdate.
-          * Therefore we need to invert the command, which is currently based on the already implemented commands
-          * in the DefaultCommandCodec.
-          */
-         return createInverseCommand(undoCommand);
+         return createInverseCommand(commandStack.getUndoCommand());
       }
       return null;
    }
 
-   public Command redo() {
-      Command redoCommand = commandStack.getRedoCommand();
+   public boolean undo() {
+      if (canUndo()) {
+         commandStack.undo();
+         return true;
+      }
+      return false;
+   }
+
+   public Command getRedoCommand() {
       if (canRedo()) {
-         commandStack.redo();
-         return redoCommand;
+         return commandStack.getRedoCommand();
       }
       return null;
+   }
+
+   public boolean redo() {
+      if (canRedo()) {
+         commandStack.redo();
+         return true;
+      }
+      return false;
    }
 
    public boolean isDirty() { return ((ModelServerCommandStack) commandStack).isSaveNeeded(); }
@@ -102,7 +114,7 @@ public class ModelServerEditingDomain extends AdapterFactoryEditingDomain {
       } else if (undoCommand instanceof RemoveCommand) {
          RemoveCommand undoRemoveCommand = (RemoveCommand) undoCommand;
          return AddCommand.create(undoRemoveCommand.getDomain(), undoRemoveCommand.getOwner(),
-            undoRemoveCommand.getFeature(), undoRemoveCommand.getResult());
+            undoRemoveCommand.getFeature(), undoRemoveCommand.getResult(), undoRemoveCommand.getIndices()[0]);
       } else if (undoCommand instanceof SetCommand) {
          // FIXME: Handle the UNSET value, see also DefaultCommandCodec where it is also not yet implemented
          SetCommand undoSetCommand = (SetCommand) undoCommand;

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/Codecs.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/Codecs.java
@@ -75,9 +75,10 @@ public class Codecs implements CodecsManager {
     */
    @Inject
    public Codecs(final Map<String, Codec> emfCodecs) {
-   }
       formatToCodec.putAll(emfCodecs);
+   }
 
+   @Override
    public Map<String, JsonNode> encode(final EObject eObject) throws EncodingException {
       Map<String, JsonNode> encodings = new LinkedHashMap<>();
       formatToCodec.forEach((key, codec) -> {
@@ -111,11 +112,9 @@ public class Codecs implements CodecsManager {
       return findFormat(context.queryParamMap()).decode(payload, workspaceURI);
    }
 
+   @Override
    public String findFormat(final WsContext context) {
-      if (context.queryParamMap().containsKey(ModelServerPathParameters.FORMAT)) {
-         return context.queryParamMap().get(ModelServerPathParameters.FORMAT).get(0);
-      }
-      return ModelServerPathParameters.FORMAT_JSON;
+      return context.queryParam(ModelServerPathParameters.FORMAT, ModelServerPathParameters.FORMAT_JSON);
    }
 
    private Codec findFormat(final Map<String, List<String>> queryParams) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/Codecs.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/Codecs.java
@@ -75,7 +75,19 @@ public class Codecs implements CodecsManager {
     */
    @Inject
    public Codecs(final Map<String, Codec> emfCodecs) {
+   }
       formatToCodec.putAll(emfCodecs);
+
+   public Map<String, JsonNode> encode(final EObject eObject) throws EncodingException {
+      Map<String, JsonNode> encodings = new LinkedHashMap<>();
+      formatToCodec.forEach((key, codec) -> {
+         try {
+            encodings.put(key, codec.encode(eObject));
+         } catch (EncodingException e) {
+            e.printStackTrace();
+         }
+      });
+      return encodings;
    }
 
    @Override
@@ -99,7 +111,14 @@ public class Codecs implements CodecsManager {
       return findFormat(context.queryParamMap()).decode(payload, workspaceURI);
    }
 
-   protected Codec findFormat(final Map<String, List<String>> queryParams) {
+   public String findFormat(final WsContext context) {
+      if (context.queryParamMap().containsKey(ModelServerPathParameters.FORMAT)) {
+         return context.queryParamMap().get(ModelServerPathParameters.FORMAT).get(0);
+      }
+      return ModelServerPathParameters.FORMAT_JSON;
+   }
+
+   private Codec findFormat(final Map<String, List<String>> queryParams) {
       return Optional
          .ofNullable(queryParams.get(ModelServerPathParameters.FORMAT))
          .filter(list -> !list.isEmpty())

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/CodecsManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/CodecsManager.java
@@ -10,6 +10,7 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common.codecs;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.emf.common.util.URI;
@@ -38,6 +39,15 @@ public interface CodecsManager {
     * @return preferred format value
     */
    String getPreferredFormat();
+
+   /**
+    * Encode an EObject to JsonNodes in all available formats.
+    *
+    * @param eObject
+    * @return a map containing all format strings and their encoded JsonNodes
+    * @throws EncodingException
+    */
+   Map<String, JsonNode> encode(EObject eObject) throws EncodingException;
 
    /**
     * Encode an EObject to a JsonNode.
@@ -80,5 +90,13 @@ public interface CodecsManager {
     */
    Optional<EObject> decode(Context context, String payload, URI workspaceURI)
       throws DecodingException;
+
+   /**
+    * Returns the format, for which the websocket subscribed for.
+    *
+    * @param context the javalin websocket context
+    * @return format string
+    */
+   String findFormat(WsContext context);
 
 }


### PR DESCRIPTION
- Ensure undo/redo commands can be encoded to broadcast to all listeners
  - Especially for XMI listeners it is therefore necessary to encode the commands before actual undo/redo as the encoding using the already changed resource leads cannot be completed.

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>