### PR TITLE
Improve extensibility of model server formats and codecs #60

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -60,7 +60,7 @@ import okhttp3.WebSocketListener;
 
 public class ModelServerClient implements ModelServerClientApi<EObject>, ModelServerPaths {
 
-   private static final Set<String> SUPPORTED_FORMATS = ImmutableSet.of(ModelServerPathParameters.FORMAT_JSON,
+   private static final Set<String> DEFAULT_SUPPORTED_FORMATS = ImmutableSet.of(ModelServerPathParameters.FORMAT_JSON,
       ModelServerPathParameters.FORMAT_XMI);
    private static final String PATCH = "PATCH";
    private static final String POST = "POST";
@@ -332,7 +332,7 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
 
    private String checkedFormat(final String format) {
       if (Strings.isNullOrEmpty(format)) {
-         return ModelServerPathParameters.FORMAT_JSON;
+         return getDefaultFormat();
       }
 
       String result = format.toLowerCase();
@@ -344,9 +344,24 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
       return result;
    }
 
-   private boolean isSupportedFormat(final String format) {
-      return SUPPORTED_FORMATS.contains(format);
+   /**
+    * Test whether format is supported. You may override this method if your model server has specific format and codecs
+    * configuration.
+    *
+    * @param format the format to test.
+    * @return true when supported.
+    */
+   protected boolean isSupportedFormat(final String format) {
+      return DEFAULT_SUPPORTED_FORMATS.contains(format);
    }
+
+   /**
+    * Get the default format to use. You may override this method if your model server has specific format and codecs
+    * configuration.
+    *
+    * @return default format
+    */
+   protected String getDefaultFormat() { return ModelServerPathParameters.FORMAT_JSON; }
 
    @Override
    public CompletableFuture<Response<Boolean>> save(final String modelUri) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
@@ -26,7 +26,7 @@ import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EMFJsonConverter;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.edit.DefaultCommandCodec;
-import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 
@@ -44,11 +44,11 @@ public class ModelController {
    private final ModelRepository modelRepository;
    private final SessionController sessionController;
    private final ServerConfiguration serverConfiguration;
-   private final Codecs codecs;
+   private final CodecsManager codecs;
 
    @Inject
    public ModelController(final ModelRepository modelRepository, final SessionController sessionController,
-      final ServerConfiguration serverConfiguration, final Codecs codecs) {
+      final ServerConfiguration serverConfiguration, final CodecsManager codecs) {
 
       JavalinJackson.configure(EMFJsonConverter.setupDefaultMapper());
       this.modelRepository = modelRepository;

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
@@ -48,13 +48,13 @@ public class ModelController {
 
    @Inject
    public ModelController(final ModelRepository modelRepository, final SessionController sessionController,
-      final ServerConfiguration serverConfiguration) {
+      final ServerConfiguration serverConfiguration, final Codecs codecs) {
 
       JavalinJackson.configure(EMFJsonConverter.setupDefaultMapper());
-      codecs = new Codecs();
       this.modelRepository = modelRepository;
       this.sessionController = sessionController;
       this.serverConfiguration = serverConfiguration;
+      this.codecs = codecs;
    }
 
    public void create(final Context ctx, final String modeluri) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
@@ -24,7 +24,7 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
-import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -47,9 +47,7 @@ public class SessionController extends WsHandler {
    private ModelRepository modelRepository;
 
    @Inject
-   private Codecs encoder;
-
-   public SessionController() {}
+   private CodecsManager encoder;
 
    public boolean subscribe(final WsContext ctx, final String modeluri) {
       return this.subscribe(ctx, modeluri, -1); // Do not set an IdleTimeout, keep socket open until client disconnects

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SessionController.java
@@ -46,11 +46,10 @@ public class SessionController extends WsHandler {
    @Inject
    private ModelRepository modelRepository;
 
-   private final Codecs encoder;
+   @Inject
+   private Codecs encoder;
 
-   public SessionController() {
-      this.encoder = new Codecs();
-   }
+   public SessionController() {}
 
    public boolean subscribe(final WsContext ctx, final String modeluri) {
       return this.subscribe(ctx, modeluri, -1); // Do not set an IdleTimeout, keep socket open until client disconnects

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/Codecs.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/Codecs.java
@@ -30,26 +30,40 @@ import com.google.inject.name.Named;
 import io.javalin.http.Context;
 import io.javalin.websocket.WsContext;
 
-public class Codecs {
+public class Codecs implements CodecsManager {
 
-   /** The constant to tell which is the preferred formats in codecs. */
-   public static final String PREFERRED_FORMAT = "PreferredFormat";
-
+   /** The format we prefer to use. */
    @Inject(optional = true)
    @Named(PREFERRED_FORMAT)
    private final String preferredFormat = ModelServerPathParameters.FORMAT_JSON;
 
+   /**
+    * Get the format we prefer to use.
+    * This format should have a corresponding Codec in the manager, but it's not guaranteed when binding is overridden.
+    *
+    * @return preferred format value
+    */
+   @Override
+   public String getPreferredFormat() { return preferredFormat; }
+
    private final Map<String, Codec> formatToCodec = new LinkedHashMap<>();
 
    /**
-    * Legacy constructor in case users were instanciating Codecs class manually.
+    * Get the map of known formats and their corresponding codecs.
+    * This method can be overridden if necessary, or simply invoked in a subclass to update the map.
+    *
+    * @return map with formats and codecs
+    */
+   protected Map<String, Codec> getFormatToCodec() { return formatToCodec; }
+
+   /**
+    * Legacy constructor in case users were instantiating Codecs class manually.
     * Prefer injecting it with the correct guice bindings.
     *
     * @deprecated
     */
    @Deprecated
    public Codecs() {
-
       formatToCodec.put(ModelServerPathParameters.FORMAT_XMI, new XmiCodec());
       formatToCodec.put(ModelServerPathParameters.FORMAT_JSON, new JsonCodec());
    }
@@ -64,24 +78,28 @@ public class Codecs {
       formatToCodec.putAll(emfCodecs);
    }
 
+   @Override
    public JsonNode encode(final Context context, final EObject eObject) throws EncodingException {
       return findFormat(context.queryParamMap()).encode(eObject);
    }
 
+   @Override
    public JsonNode encode(final WsContext context, final EObject eObject) throws EncodingException {
       return findFormat(context.queryParamMap()).encode(eObject);
    }
 
+   @Override
    public Optional<EObject> decode(final Context context, final String payload) throws DecodingException {
       return findFormat(context.queryParamMap()).decode(payload);
    }
 
+   @Override
    public Optional<EObject> decode(final Context context, final String payload, final URI workspaceURI)
       throws DecodingException {
       return findFormat(context.queryParamMap()).decode(payload, workspaceURI);
    }
 
-   private Codec findFormat(final Map<String, List<String>> queryParams) {
+   protected Codec findFormat(final Map<String, List<String>> queryParams) {
       return Optional
          .ofNullable(queryParams.get(ModelServerPathParameters.FORMAT))
          .filter(list -> !list.isEmpty())

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/CodecsManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/CodecsManager.java
@@ -1,0 +1,84 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.codecs;
+
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
+import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.javalin.http.Context;
+import io.javalin.websocket.WsContext;
+
+public interface CodecsManager {
+
+   /**
+    * The constant to tell which is the preferred formats in codecs.
+    * This constant can be used for binding the value of the preferred format in DI module.
+    */
+   String PREFERRED_FORMAT = "PreferredFormat";
+
+   /**
+    * Get the format we prefer to use.
+    * This format should have a corresponding Codec in the manager, but it's not guaranteed when binding is overridden.
+    * This is generally implemented using DI and {@link #PREFERRED_FORMAT}.
+    *
+    * @return preferred format value
+    */
+   String getPreferredFormat();
+
+   /**
+    * Encode an EObject to a JsonNode.
+    *
+    * @param context the javalin http context
+    * @param eObject EObject to encode
+    * @return JsonNode
+    * @throws EncodingException when encoding failed
+    */
+   JsonNode encode(Context context, EObject eObject) throws EncodingException;
+
+   /**
+    * Encode an EObject to a JsonNode.
+    *
+    * @param context the javalin websocket context
+    * @param eObject EObject to encode
+    * @return JsonNode
+    * @throws EncodingException when encoding failed
+    */
+   JsonNode encode(WsContext context, EObject eObject) throws EncodingException;
+
+   /**
+    * Decode a JsonNode to an EObject.
+    *
+    * @param context the javalin http context
+    * @param payload tthe String payload holding EObject definition to decode
+    * @return the decoded EObject
+    * @throws DecodingException when decoding failed
+    */
+   Optional<EObject> decode(Context context, String payload) throws DecodingException;
+
+   /**
+    * Decode a JsonNode to an EObject.
+    *
+    * @param context      the javalin http context
+    * @param payload      tthe String payload holding EObject definition to decode
+    * @param workspaceURI the URI to access to the model from the workspace
+    * @return the decoded EObject
+    * @throws DecodingException when decoding failed
+    */
+   Optional<EObject> decode(Context context, String payload, URI workspaceURI)
+      throws DecodingException;
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
@@ -10,12 +10,20 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.di;
 
+import java.util.Map;
+
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
+import org.eclipse.emfcloud.modelserver.common.codecs.XmiCodec;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.edit.DefaultCommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelResourceManager;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
+
+import com.google.common.collect.Maps;
 
 public class DefaultModelServerModule extends ModelServerModule {
 
@@ -32,6 +40,14 @@ public class DefaultModelServerModule extends ModelServerModule {
    @Override
    protected Class<? extends ModelResourceManager> bindModelResourceManager() {
       return DefaultModelResourceManager.class;
+   }
+
+   @Override
+   protected Map<String, Class<? extends Codec>> bindFormatCodecs() {
+      Map<String, Class<? extends Codec>> codecs = Maps.newHashMapWithExpectedSize(2);
+      codecs.put(ModelServerPathParameters.FORMAT_XMI, XmiCodec.class);
+      codecs.put(ModelServerPathParameters.FORMAT_JSON, JsonCodec.class);
+      return codecs;
    }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
@@ -29,6 +29,7 @@ import org.eclipse.emfcloud.modelserver.emf.common.SchemaController;
 import org.eclipse.emfcloud.modelserver.emf.common.SchemaRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.configuration.CommandPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EcorePackageConfiguration;
@@ -80,6 +81,7 @@ public abstract class ModelServerModule extends AbstractModule {
       bind(AdapterFactory.class).toInstance(bindAdapterFactory());
       bind(CommandCodec.class).to(bindCommandCodec()).in(Singleton.class);
       bind(ModelResourceManager.class).to(bindModelResourceManager()).in(Singleton.class);
+      bind(CodecsManager.class).to(bindCodecsManager()).in(Singleton.class);
       MapBinder<String, Codec> codecsBinder = MapBinder.newMapBinder(binder(), String.class, Codec.class);
       bindFormatCodecs().forEach((format, codec) -> codecsBinder.addBinding(format).to(codec));
 
@@ -111,11 +113,23 @@ public abstract class ModelServerModule extends AbstractModule {
    protected abstract Class<? extends ModelResourceManager> bindModelResourceManager();
 
    /**
+    * Bind the codecs manager implementating class.
+    *
+    * @return the condecs manager implementation class.
+    */
+   protected Class<? extends CodecsManager> bindCodecsManager() {
+      return Codecs.class;
+   }
+
+   /**
     * Bind the EObject codecs to support various formats encoding and decoding.
     * <p>
     * Note that in case you don't support Json or don't want it as the default format, you may bind an alternative one
-    * to the key {@link Codecs#PREFERRED_FORMAT}.
+    * to the key {@link CodecsManager#PREFERRED_FORMAT}.
     * </p>
+    * <p>
+    * Note this binding may also no longer be relevant in case you override the {@link #bindCodecsManager()} method.
+    * </>
     *
     * @return map with formats as key and codec classes to instantiate as values.
     */

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
@@ -12,12 +12,14 @@ package org.eclipse.emfcloud.modelserver.emf.di;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emfcloud.modelserver.common.AppEntryPoint;
 import org.eclipse.emfcloud.modelserver.common.EntryPointType;
 import org.eclipse.emfcloud.modelserver.common.Routing;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelController;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
@@ -26,6 +28,7 @@ import org.eclipse.emfcloud.modelserver.emf.common.ModelServerRouting;
 import org.eclipse.emfcloud.modelserver.emf.common.SchemaController;
 import org.eclipse.emfcloud.modelserver.emf.common.SchemaRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
 import org.eclipse.emfcloud.modelserver.emf.configuration.CommandPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EcorePackageConfiguration;
@@ -77,6 +80,8 @@ public abstract class ModelServerModule extends AbstractModule {
       bind(AdapterFactory.class).toInstance(bindAdapterFactory());
       bind(CommandCodec.class).to(bindCommandCodec()).in(Singleton.class);
       bind(ModelResourceManager.class).to(bindModelResourceManager()).in(Singleton.class);
+      MapBinder<String, Codec> codecsBinder = MapBinder.newMapBinder(binder(), String.class, Codec.class);
+      bindFormatCodecs().forEach((format, codec) -> codecsBinder.addBinding(format).to(codec));
 
    }
 
@@ -104,5 +109,16 @@ public abstract class ModelServerModule extends AbstractModule {
    protected abstract Class<? extends CommandCodec> bindCommandCodec();
 
    protected abstract Class<? extends ModelResourceManager> bindModelResourceManager();
+
+   /**
+    * Bind the EObject codecs to support various formats encoding and decoding.
+    * <p>
+    * Note that in case you don't support Json or don't want it as the default format, you may bind an alternative one
+    * to the key {@link Codecs#PREFERRED_FORMAT}.
+    * </p>
+    *
+    * @return map with formats as key and codec classes to instantiate as values.
+    */
+   protected abstract Map<String, Class<? extends Codec>> bindFormatCodecs();
 
 }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/ModelControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/ModelControllerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,9 +43,11 @@ import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.command.CommandKind;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.XmiCodec;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
@@ -78,12 +81,17 @@ public class ModelControllerTest {
    @Mock
    private ServerConfiguration serverConfiguration;
 
+   private Codecs codecs;
+
    private ModelController modelController;
 
    @Before
    public void before() {
       when(serverConfiguration.getWorkspaceRootURI()).thenReturn(URI.createFileURI("/home/modelserver/workspace/"));
-      modelController = new ModelController(modelRepository, sessionController, serverConfiguration);
+      Map<String, Codec> formatsToCodecsMap = new HashMap<>(1);
+      formatsToCodecsMap.put(ModelServerPathParameters.FORMAT_XMI, new XmiCodec());
+      codecs = new Codecs(formatsToCodecsMap);
+      modelController = new ModelController(modelRepository, sessionController, serverConfiguration, codecs);
    }
 
    @Test

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/ModelControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/ModelControllerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,11 +42,11 @@ import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.command.CommandKind;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
-import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.XmiCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
@@ -81,16 +80,14 @@ public class ModelControllerTest {
    @Mock
    private ServerConfiguration serverConfiguration;
 
-   private Codecs codecs;
+   private CodecsManager codecs;
 
    private ModelController modelController;
 
    @Before
    public void before() {
       when(serverConfiguration.getWorkspaceRootURI()).thenReturn(URI.createFileURI("/home/modelserver/workspace/"));
-      Map<String, Codec> formatsToCodecsMap = new HashMap<>(1);
-      formatsToCodecsMap.put(ModelServerPathParameters.FORMAT_XMI, new XmiCodec());
-      codecs = new Codecs(formatsToCodecsMap);
+      codecs = new Codecs(Map.of(ModelServerPathParameters.FORMAT_XMI, new XmiCodec()));
       modelController = new ModelController(modelRepository, sessionController, serverConfiguration, codecs);
    }
 

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SessionControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SessionControllerTest.java
@@ -27,7 +27,7 @@ import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.command.CommandKind;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
-import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.jetty.websocket.api.Session;
 import org.hamcrest.CustomTypeSafeMatcher;
@@ -69,7 +69,7 @@ public class SessionControllerTest {
    @Mock
    private ModelResourceManager modelResourceManager;
    @Mock
-   private Codecs codecs;
+   private CodecsManager codecs;
 
    private SessionController sessionController;
 
@@ -213,7 +213,7 @@ public class SessionControllerTest {
             bind(CommandCodec.class).toInstance(commandCodec);
             bind(ModelRepository.class).toInstance(repository);
             bind(ModelResourceManager.class).toInstance(modelResourceManager);
-            bind(Codecs.class).toInstance(codecs);
+            bind(CodecsManager.class).toInstance(codecs);
          }
       }).getInstance(SessionController.class);
 

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SessionControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/SessionControllerTest.java
@@ -27,6 +27,7 @@ import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.command.CommandKind;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.Codecs;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.jetty.websocket.api.Session;
 import org.hamcrest.CustomTypeSafeMatcher;
@@ -67,6 +68,8 @@ public class SessionControllerTest {
    private ModelRepository repository;
    @Mock
    private ModelResourceManager modelResourceManager;
+   @Mock
+   private Codecs codecs;
 
    private SessionController sessionController;
 
@@ -210,6 +213,7 @@ public class SessionControllerTest {
             bind(CommandCodec.class).toInstance(commandCodec);
             bind(ModelRepository.class).toInstance(repository);
             bind(ModelResourceManager.class).toInstance(modelResourceManager);
+            bind(Codecs.class).toInstance(codecs);
          }
       }).getInstance(SessionController.class);
 


### PR DESCRIPTION
Use Map binding for codecs and format. Also give the possibility to
specify a preferred format (json by default).
The Model Server Client now has overrideable methods so that it can
change the accepteable formats when necessary.

Signed-off-by: vhemery <vincent.hemery@csgroup.eu>