### PR TITLE
Process incoming requests after server configuration is completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ The following table shows the current HTTP endpoints:
 
 <br/>
 
+Per default, updating the server configuration (`/server/configure`) with a new workspaceRoot, enables queueing of further incoming requests until configuration is completed.
+Please see `ModelServerRouting` for details.
+
+<br/>
+
 ### WebSocket Endpoints
 
 Subscriptions are implemented via websockets `ws://localhost:8081/api/v1/*`.

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -172,7 +172,7 @@ public class DefaultModelResourceManager implements ModelResourceManager {
          resource.load(Collections.EMPTY_MAP);
          return Optional.of(resource);
       } catch (final Throwable e) {
-         LOG.error("Could not load resource with URI: " + modeluri);
+         LOG.debug("Could not load resource with URI: " + modeluri);
          if (removeUnloadableResources) {
             // properly remove model again so the resource set does not hold a broken resource
             removeResourceSafe(modeluri);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRouting.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRouting.java
@@ -10,6 +10,8 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
+import static io.javalin.apibuilder.ApiBuilder.after;
+import static io.javalin.apibuilder.ApiBuilder.before;
 import static io.javalin.apibuilder.ApiBuilder.delete;
 import static io.javalin.apibuilder.ApiBuilder.get;
 import static io.javalin.apibuilder.ApiBuilder.patch;
@@ -21,6 +23,7 @@ import static io.javalin.apibuilder.ApiBuilder.ws;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
@@ -42,17 +45,31 @@ public class ModelServerRouting extends Routing {
    private final Javalin javalin;
    private final ServerConfiguration serverConfiguration;
 
+   // Do not process certain requests while server is being configured.
+   protected CompletableFuture<Void> onServerConfigured;
+
    @Inject
    public ModelServerRouting(final Javalin javalin, final ServerConfiguration serverConfiguration) {
       this.javalin = javalin;
       this.serverConfiguration = serverConfiguration;
+      this.onServerConfigured = CompletableFuture.completedFuture(null);
    }
 
    @Override
-   @SuppressWarnings("checkstyle:MethodLength")
+   @SuppressWarnings({ "checkstyle:MethodLength", "JavaNCSS", "checkstyle:CyclomaticComplexity" })
    public void bindRoutes() {
       javalin.routes(() -> {
          path("api/v1", () -> {
+
+            // Wait until all preconditions are fulfilled
+            before(ctx -> {
+               if (requiresConfiguredServer(ctx) && !this.onServerConfigured.isDone()) {
+                  String requestPath = ctx.path() + (ctx.queryString() == null ? "" : "?" + ctx.queryString());
+                  LOG.debug("Waiting for sever configuration to be completed: " + requestPath);
+                  this.onServerConfigured.get();
+               }
+            });
+
             // CREATE
             post(ModelServerPaths.MODEL_BASE_PATH, ctx -> {
                getQueryParam(ctx.queryParamMap(), ModelServerPathParameters.MODEL_URI)
@@ -168,7 +185,19 @@ public class ModelServerRouting extends Routing {
             });
 
             // SERVER CONFIGURATION
-            put(ModelServerPaths.SERVER_CONFIGURE, getController(ServerController.class).getConfigureHandler());
+            before(ModelServerPaths.SERVER_CONFIGURE, ctx -> {
+               LOG.debug("SERVER_CONFIGURE started");
+               this.onServerConfigured = new CompletableFuture<>();
+            });
+
+            put(ModelServerPaths.SERVER_CONFIGURE, ctx -> {
+               ctx.result(getController(ServerController.class).configure(ctx));
+            });
+
+            after(ModelServerPaths.SERVER_CONFIGURE, ctx -> {
+               LOG.debug("SERVER_CONFIGURE completed -> pending requests will be processed now");
+               this.onServerConfigured.complete(null);
+            });
 
             // PING SERVER
             get(ModelServerPaths.SERVER_PING, getController(ServerController.class).getPingHandler());
@@ -218,6 +247,11 @@ public class ModelServerRouting extends Routing {
       });
    }
 
+   protected boolean requiresConfiguredServer(final Context ctx) {
+      return !ctx.path().contains(ModelServerPaths.SERVER_CONFIGURE)
+         && !ctx.path().contains(ModelServerPaths.SERVER_PING);
+   }
+
    private Optional<String> getQueryParam(final Map<String, List<String>> queryParams, final String paramKey) {
       if (queryParams.containsKey(paramKey)) {
          return Optional.of(queryParams.get(paramKey).get(0));
@@ -241,8 +275,9 @@ public class ModelServerRouting extends Routing {
          }
          return URI.createFileURI(modelUri).toString();
       }
-
-      return uri.toString();
+      // Create file URI from path if modelUri is already absolute path (file:/ or full path file:///)
+      // to ensure consistent usage of org.eclipse.emf.common.util.URI
+      return URI.createFileURI(uri.path()).toString();
    }
 
    private void handleHttpError(final Context ctx, final int statusCode, final String errorMsg) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ServerController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ServerController.java
@@ -10,10 +10,13 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Inject;
 
 import io.javalin.http.Context;
@@ -30,16 +33,18 @@ public class ServerController {
       ctx.json(JsonResponse.success());
    }
 
-   protected void configure(final Context ctx) {
+   public CompletableFuture<ObjectNode> configure(final Context ctx) {
       ServerConfiguration newConf = ctx.bodyAsClass(ServerConfiguration.class);
+      CompletableFuture<ObjectNode> future = new CompletableFuture<>();
       try {
          if (updateServerConfiguration(newConf)) {
             modelRepository.initialize();
-            ctx.json(JsonResponse.success());
+            return CompletableFuture.completedFuture(JsonResponse.success());
          }
       } catch (IllegalArgumentException exception) {
          handleError(ctx, 400, exception.getMessage());
       }
+      return future;
    }
 
    protected boolean updateServerConfiguration(final ServerConfiguration newConfiguration) {
@@ -69,7 +74,5 @@ public class ServerController {
    }
 
    public Handler getPingHandler() { return this::ping; }
-
-   public Handler getConfigureHandler() { return this::configure; }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
@@ -10,17 +10,21 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.di;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
+import org.eclipse.emfcloud.modelserver.common.Routing;
 import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.common.codecs.XmiCodec;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.edit.DefaultCommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelResourceManager;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelServerRouting;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 
 import com.google.common.collect.Maps;
@@ -48,6 +52,13 @@ public class DefaultModelServerModule extends ModelServerModule {
       codecs.put(ModelServerPathParameters.FORMAT_XMI, XmiCodec.class);
       codecs.put(ModelServerPathParameters.FORMAT_JSON, JsonCodec.class);
       return codecs;
+   }
+
+   @Override
+   protected Set<Class<? extends Routing>> bindModelServerRoutings() {
+      Set<Class<? extends Routing>> routings = new HashSet<>();
+      routings.add(ModelServerRouting.class);
+      return routings;
    }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
@@ -13,6 +13,7 @@ package org.eclipse.emfcloud.modelserver.emf.di;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.notify.AdapterFactory;
@@ -24,7 +25,6 @@ import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelController;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
-import org.eclipse.emfcloud.modelserver.emf.common.ModelServerRouting;
 import org.eclipse.emfcloud.modelserver.emf.common.SchemaController;
 import org.eclipse.emfcloud.modelserver.emf.common.SchemaRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
@@ -72,7 +72,6 @@ public abstract class ModelServerModule extends AbstractModule {
       bind(SchemaController.class).in(Singleton.class);
       bind(SchemaRepository.class).in(Singleton.class);
       bind(SessionController.class).in(Singleton.class);
-      Multibinder.newSetBinder(binder(), Routing.class).addBinding().to(ModelServerRouting.class).in(Singleton.class);
       MapBinder.newMapBinder(binder(), EntryPointType.class, AppEntryPoint.class).addBinding(EntryPointType.REST)
          .to(ModelServerEntryPoint.class);
 
@@ -84,7 +83,8 @@ public abstract class ModelServerModule extends AbstractModule {
       bind(CodecsManager.class).to(bindCodecsManager()).in(Singleton.class);
       MapBinder<String, Codec> codecsBinder = MapBinder.newMapBinder(binder(), String.class, Codec.class);
       bindFormatCodecs().forEach((format, codec) -> codecsBinder.addBinding(format).to(codec));
-
+      Multibinder<Routing> routingBinder = Multibinder.newSetBinder(binder(), Routing.class);
+      bindModelServerRoutings().forEach(routing -> routingBinder.addBinding().to(routing).in(Singleton.class));
    }
 
    public void addEPackageConfigurations(final Collection<Class<? extends EPackageConfiguration>> configs) {
@@ -95,8 +95,10 @@ public abstract class ModelServerModule extends AbstractModule {
       return Javalin.create(config -> {
          config.enableCorsForAllOrigins();
          config.requestLogger((ctx, ms) -> {
-            LOG.info(ctx.method() + " " + ctx.path() + " -> Status: " + ctx.status() + " (took " + ms + " ms)");
+            String requestPath = ctx.path() + (ctx.queryString() == null ? "" : "?" + ctx.queryString());
+            LOG.info(ctx.method() + " " + requestPath + " -> Status: " + ctx.status() + " (took " + ms + " ms)");
          });
+         config.asyncRequestTimeout = 5000L;
          config.wsLogger(ws -> {
             ws.onConnect(ctx -> LOG.info("WS Connected: " + ctx.getSessionId()));
             ws.onMessage(ctx -> LOG.info("WS Received: " + ctx.message() + " by " + ctx.getSessionId()));
@@ -134,5 +136,7 @@ public abstract class ModelServerModule extends AbstractModule {
     * @return map with formats as key and codec classes to instantiate as values.
     */
    protected abstract Map<String, Class<? extends Codec>> bindFormatCodecs();
+
+   protected abstract Set<Class<? extends Routing>> bindModelServerRoutings();
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/ModelServerLauncher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/launch/ModelServerLauncher.java
@@ -44,7 +44,7 @@ public class ModelServerLauncher {
          root.addAppender(new ConsoleAppender(
             new PatternLayout(PatternLayout.TTCC_CONVERSION_PATTERN)));
       }
-      root.setLevel(Level.INFO);
+      root.setLevel(Level.DEBUG);
 
    }
 


### PR DESCRIPTION
- Fixes #71: Process incoming requests after server configuration is completed
  - Make ModelServerRouting configurable via DI
- Enhance logging of request routing
- Change some log lines to debug level
- Change default debug level to DEBUG
- Fixes #72: Absolute full path as modelURI causes error

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>