### PR TITLE
Fix #75 Request server/configure does not deliver JsonResponse

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRouting.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRouting.java
@@ -191,7 +191,7 @@ public class ModelServerRouting extends Routing {
             });
 
             put(ModelServerPaths.SERVER_CONFIGURE, ctx -> {
-               ctx.result(getController(ServerController.class).configure(ctx));
+               getController(ServerController.class).configure(ctx).thenApply(ctx::json);
             });
 
             after(ModelServerPaths.SERVER_CONFIGURE, ctx -> {


### PR DESCRIPTION
Add correct json response for server configuration request

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>