### PR TITLE
Fix #87: Adapt command package namespace URI to better reflect source

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.edit/plugin.xml
+++ b/bundles/org.eclipse.emfcloud.modelserver.edit/plugin.xml
@@ -17,7 +17,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated Command -->
       <package
-            uri="http://www.eclipsesource.com/schema/2019/modelserver/command"
+            uri="http://www.eclipse.org/emfcloud/modelserver/command"
             class="org.eclipse.emfcloud.modelserver.command.CCommandPackage"
             genModel="resources/Command.genmodel"/>
    </extension>

--- a/bundles/org.eclipse.emfcloud.modelserver.edit/resources/Command.ecore
+++ b/bundles/org.eclipse.emfcloud.modelserver.edit/resources/Command.ecore
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="command" nsURI="http://www.eclipsesource.com/schema/2019/modelserver/command"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="command" nsURI="http://www.eclipse.org/emfcloud/modelserver/command"
     nsPrefix="cmd">
   <eClassifiers xsi:type="ecore:EClass" name="Command">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/bundles/org.eclipse.emfcloud.modelserver.edit/src-gen/org/eclipse/emfcloud/modelserver/command/CCommandPackage.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.edit/src-gen/org/eclipse/emfcloud/modelserver/command/CCommandPackage.java
@@ -49,7 +49,7 @@ public interface CCommandPackage extends EPackage {
     *
     * @generated
     */
-   String eNS_URI = "http://www.eclipsesource.com/schema/2019/modelserver/command";
+   String eNS_URI = "http://www.eclipse.org/emfcloud/modelserver/command";
 
    /**
     * The package namespace name.

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -368,10 +368,13 @@ public class DefaultModelResourceManager implements ModelResourceManager {
       CCommandExecutionResult result = CCommandFactory.eINSTANCE.createCommandExecutionResult();
       result.setType(context.getType());
       result.setSource(EcoreUtil.copy(context.getClientCommand()));
-      context.getServerCommand().getAffectedObjects().stream()
-         .filter(EObject.class::isInstance)
-         .map(EObject.class::cast)
-         .forEach(result.getAffectedObjects()::add);
+      Collection<?> affectedObjects = context.getServerCommand().getAffectedObjects();
+      if (affectedObjects != null) {
+         affectedObjects.stream()
+            .filter(EObject.class::isInstance)
+            .map(EObject.class::cast)
+            .forEach(result.getAffectedObjects()::add);
+      }
       return result;
    }
 

--- a/tests/org.eclipse.emfcloud.modelserver.edit.tests/resources/Command.xmi
+++ b/tests/org.eclipse.emfcloud.modelserver.edit.tests/resources/Command.xmi
@@ -3,7 +3,7 @@
     xmi:version="2.0"
     xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:cmd="http://www.eclipsesource.com/schema/2019/modelserver/command"
+    xmlns:cmd="http://www.eclipse.org/emfcloud/modelserver/command"
     type="set"
     feature="name">
   <owner href="Coffee.ecore#//@eClassifiers.0"/>

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionControllerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
+import org.eclipse.emfcloud.modelserver.command.CCommandPackage;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
@@ -166,7 +167,7 @@ public class DefaultSessionControllerTest {
       JsonNode expectedCommand = Json.object(
          prop("type", Json.text("execute")),
          prop("source", Json.object(
-            prop("eClass", Json.text("http://www.eclipsesource.com/schema/2019/modelserver/command#//Command")),
+            prop("eClass", Json.text(EcoreUtil.getURI(CCommandPackage.Literals.COMMAND).toString())),
             prop("type", Json.text(command.getType().toString())),
             prop("owner", Json.object(
                prop("eClass", Json.text("")),


### PR DESCRIPTION
- Use http://www.eclipse.org/emfcloud/modelserver/command as NS URI
- Adapt URI where necessary

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>