### PR TITLE
#108 Disable macOS 10.15 runner for build-m2 action temporarily

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       # do not cancel other builds if one fails
       fail-fast: false
       matrix:
-        os: [windows-2019, ubuntu-18.04, macos-10.15]
+        os: [windows-2019, ubuntu-18.04]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20


### PR DESCRIPTION
- Add ubuntu-latest to Github Actions runners
- Disable MacOS 10.15. (macOS-latest) temporarily for m2 build in GitHub Actions
- MacOS 11.0 is not available publicly yet (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)