### PR TITLE
Fix #111: Add error/failure logging and centralize package configs

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.client/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: com.fasterxml.jackson.core.jackson-core;bundle-version="[2.9.0,3
  org.eclipse.emfcloud.modelserver.common;bundle-version="[0.7.0,1.0.0)",
  org.eclipse.emfcloud.modelserver.edit;bundle-version="[0.7.0,1.0.0)",
  org.eclipse.emfcloud.modelserver.lib;bundle-version="[0.7.0,1.0.0)",
- org.eclipse.emfcloud.modelserver.emf;bundle-version="[0.7.0,1.0.0)"
+ org.eclipse.emfcloud.modelserver.emf;bundle-version="[0.7.0,1.0.0)",
+ org.eclipse.emf.ecore.change;bundle-version="[2.14.0,3.0.0)"
 Export-Package: org.eclipse.emfcloud.modelserver.client,
  org.eclipse.emfcloud.modelserver.internal.client;x-internal:=true
 Bundle-Vendor: EclipseSource

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/TypedSubscriptionListener.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/TypedSubscriptionListener.java
@@ -13,9 +13,12 @@ package org.eclipse.emfcloud.modelserver.client;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.apache.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.emf.common.JsonResponseType;
 
 public class TypedSubscriptionListener<T> implements NotificationSubscriptionListener<T> {
+   private static Logger LOG = Logger.getLogger(TypedSubscriptionListener.class.getSimpleName());
+
    private final Function<? super String, Optional<T>> updateFunction;
 
    public TypedSubscriptionListener(final Function<String, Optional<T>> updateFunction) {
@@ -55,7 +58,9 @@ public class TypedSubscriptionListener<T> implements NotificationSubscriptionLis
    public void onSuccess(final Optional<String> message) {}
 
    @Override
-   public void onError(final Optional<String> message) {}
+   public void onError(final Optional<String> message) {
+      LOG.error("Error: " + message.orElse("Unknown"));
+   }
 
    @Override
    public void onDirtyChange(final boolean isDirty) {}
@@ -67,7 +72,9 @@ public class TypedSubscriptionListener<T> implements NotificationSubscriptionLis
    public void onIncrementalUpdate(final T incrementalUpdate) {}
 
    @Override
-   public void onUnknown(final ModelServerNotification notification) {}
+   public void onUnknown(final ModelServerNotification notification) {
+      LOG.warn("Unknown notification type: " + notification.getType());
+   }
 
    @Override
    public void onOpen(final Response<String> response) {}
@@ -79,8 +86,12 @@ public class TypedSubscriptionListener<T> implements NotificationSubscriptionLis
    public void onClosed(final int code, final String reason) {}
 
    @Override
-   public void onFailure(final Throwable t, final Response<String> response) {}
+   public void onFailure(final Throwable throwable, final Response<String> response) {
+      LOG.error("Failure: " + response.getMessage(), throwable);
+   }
 
    @Override
-   public void onFailure(final Throwable t) {}
+   public void onFailure(final Throwable throwable) {
+      LOG.error("Failure: ", throwable);
+   }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/RecordingModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/RecordingModelResourceManager.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.change.ChangeDescription;
 import org.eclipse.emf.ecore.change.util.ChangeRecorder;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
+import org.eclipse.emfcloud.modelserver.emf.configuration.ChangePackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 
@@ -35,6 +36,12 @@ public class RecordingModelResourceManager extends DefaultModelResourceManager {
       final AdapterFactory adapterFactory,
       final ServerConfiguration serverConfiguration) {
       super(configurations, adapterFactory, serverConfiguration);
+   }
+
+   @Override
+   public void initialize() {
+      this.configurations.add(new ChangePackageConfiguration());
+      super.initialize();
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ChangePackageConfiguration.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/configuration/ChangePackageConfiguration.java
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.configuration;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.emf.ecore.change.ChangePackage;
+
+public class ChangePackageConfiguration implements EPackageConfiguration {
+
+   @Override
+   public Collection<String> getFileExtensions() { return Collections.emptyList(); }
+
+   @Override
+   public void registerEPackage() {
+      ChangePackage.eINSTANCE.eClass();
+   }
+
+   @Override
+   public String getId() { return ChangePackage.eNS_URI; }
+
+}

--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
@@ -22,9 +22,9 @@ import org.eclipse.emfcloud.modelserver.client.Response;
 import org.eclipse.emfcloud.modelserver.client.SubscriptionListener;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeePackage;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
-import org.eclipse.emfcloud.modelserver.command.CCommandPackage;
 import org.eclipse.emfcloud.modelserver.edit.command.SetCommandContribution;
 import org.eclipse.emfcloud.modelserver.edit.util.CommandUtil;
+import org.eclipse.emfcloud.modelserver.example.CoffeePackageConfiguration;
 import org.eclipse.emfcloud.modelserver.example.UpdateTaskNameCommandContribution;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 
@@ -48,8 +48,9 @@ public final class ExampleModelServerClient {
    private ExampleModelServerClient() {}
 
    public static void main(final String[] args) {
-      registerPackages();
-      try (ModelServerClient client = new ModelServerClient("http://localhost:8081/api/v1/");
+      try (
+         ModelServerClient client = new ModelServerClient("http://localhost:8081/api/v1/",
+            new CoffeePackageConfiguration());
          Scanner userInput = new Scanner(System.in)) {
          System.out.println("Simple Model Server Client Interface");
          System.out.println("====================================");
@@ -164,12 +165,6 @@ public final class ExampleModelServerClient {
       String modelUri = command.length >= 1 ? command[1] : "";
       client.unsubscribe(modelUri);
       System.out.println("< OK");
-   }
-
-   private static void registerPackages() {
-      EcorePackage.eINSTANCE.eClass();
-      CCommandPackage.eINSTANCE.eClass();
-      CoffeePackage.eINSTANCE.eClass();
    }
 
    private static void printHelp() {


### PR DESCRIPTION
Logging:
We want to to log errors and failures by default to prevent those
problems from being swallowed up since they may contain important
information about underlying issues.

EPackageConfigurations:
Centralize EPackageConfiguration management and apply it on the Java
model server client to ensure proper setup. We also ensure that the
ChangePackage is properly initialized on the client-side. We already use
the RecordingModelResourceManager as default on the server so we need
the ChangePackage to be initialized.