### PR TITLE
#99 : New API endpoint to close resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following table shows the current HTTP endpoints:
 | |Create new model|__POST__|`/models`|query parameter: `?modeluri=...[&format=...]` <br> application/json
 | |Update model|__PATCH__|`/models`|query parameter: `?modeluri=...[&format=...]` <br> application/json
 | |Delete model|__DELETE__|`/models`|query parameter: `?modeluri=...`
+| |Close model|__POST__|`/close`|query parameter: `?modeluri=...`
 | |Save|__GET__|`/save`|query parameter: `?modeluri=...`
 | |SaveAll|__GET__|`/saveall`| -
 | |Undo|__GET__|`/undo`|query parameter: `?modeluri=...`
@@ -139,6 +140,8 @@ public interface ModelServerClientApiV1<A> {
    CompletableFuture<Response<A>> getModelElementByName(String modelUri, String elementname, String format);
 
    CompletableFuture<Response<Boolean>> delete(String modelUri);
+
+   CompletableFuture<Response<Boolean>> close(String modelUri);
 
    CompletableFuture<Response<String>> create(String modelUri, String createdModelAsJsonText);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -296,6 +296,19 @@ public class ModelServerClient implements ModelServerClientApi<EObject>, ModelSe
    }
 
    @Override
+   public CompletableFuture<Response<Boolean>> close(final String modelUri) {
+      final Request request = new Request.Builder()
+         .url(
+            createHttpUrlBuilder(makeUrl(CLOSE))
+               .addQueryParameter(ModelServerPathParametersV1.MODEL_URI, modelUri)
+               .build())
+         .post(RequestBody.create(new byte[0]))
+         .build();
+
+      return makeCallAndExpectSuccess(request);
+   }
+
+   @Override
    public CompletableFuture<Response<String>> create(final String modelUri, final String createdModelAsJsonText) {
       TextNode dataNode = Json.text(createdModelAsJsonText);
       final Request request = buildCreateOrUpdateRequest(modelUri, POST, ModelServerPathParametersV1.FORMAT_JSON,

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV1.java
@@ -37,6 +37,8 @@ public interface ModelServerClientApiV1<A> {
 
    CompletableFuture<Response<Boolean>> delete(String modelUri);
 
+   CompletableFuture<Response<Boolean>> close(String modelUri);
+
    CompletableFuture<Response<String>> create(String modelUri, String createdModelAsJsonText);
 
    CompletableFuture<Response<A>> create(String modelUri, A createdModel, String format);

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/ModelServerPathsV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/ModelServerPathsV1.java
@@ -19,6 +19,7 @@ public interface ModelServerPathsV1 {
    String MODEL_URIS = "modeluris";
 
    String SUBSCRIPTION = "subscribe"; // accepts query parameter "modeluri"
+   String CLOSE = "close"; // accepts query parameter "modeluri"
    String EDIT = "edit"; // accepts query parameter "modeluri"
    String SAVE = "save"; // accepts query parameter "modeluri"
    String SAVE_ALL = "saveall";

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
@@ -107,6 +107,17 @@ public class DefaultModelController implements ModelController {
    }
 
    @Override
+   public void close(final Context ctx, final String modeluri) {
+      if (this.modelRepository.hasModel(modeluri)) {
+         this.modelRepository.closeModel(modeluri);
+         success(ctx, "Model '%s' successfully closed", modeluri);
+         this.sessionController.modelClosed(modeluri);
+      } else {
+         ContextResponse.modelNotFound(ctx, modeluri);
+      }
+   }
+
+   @Override
    public void getAll(final Context ctx) {
       try {
          final Map<URI, EObject> allModels = this.modelRepository.getAllModels();

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelRepository.java
@@ -143,6 +143,11 @@ public class DefaultModelRepository implements ModelRepository {
    }
 
    @Override
+   public void closeModel(final String modeluri) {
+      modelResourceManager.closeResource(modeluri);
+   }
+
+   @Override
    public boolean saveModel(final String modeluri) {
       return modelResourceManager.save(modeluri);
    }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionController.java
@@ -142,6 +142,17 @@ public class DefaultSessionController implements SessionController {
    }
 
    @Override
+   public void modelClosed(final String modeluri) {
+      // depending on resource manager, model may have been automatically reloaded or not
+      boolean isLoaded = modelRepository.hasModel(modeluri);
+      if (isLoaded) {
+         modelUpdated(modeluri);
+      } else {
+         broadcastFullUpdate(modeluri, null);
+      }
+   }
+
+   @Override
    public void modelSaved(final String modeluri) {
       broadcastDirtyState(modeluri, modelRepository.getDirtyState(modeluri));
    }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
@@ -17,6 +17,8 @@ public interface ModelController {
 
    void delete(Context ctx, String modeluri);
 
+   void close(Context ctx, String modeluri);
+
    void getAll(Context ctx);
 
    void getOne(Context ctx, String modeluri);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelListener.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelListener.java
@@ -21,6 +21,13 @@ public interface ModelListener {
 
    void modelDeleted(String modeluri);
 
+   /**
+    * Notifies when a model resource is closed.
+    *
+    * @param modeluri the concerned model's URI
+    */
+   void modelClosed(String modeluri);
+
    void modelSaved(String modeluri);
 
    void allModelsSaved();

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
@@ -45,6 +45,14 @@ public interface ModelRepository {
 
    void deleteModel(String modeluri) throws IOException;
 
+   /**
+    * Closes a model, forgetting about its content and any current modification.
+    * Model can be reopened later from its persisted state with a simple {@link #loadResource(String)} call.
+    *
+    * @param modeluri the URI of the model resource
+    */
+   void closeModel(String modeluri);
+
    boolean saveModel(String modeluri);
 
    boolean saveAllModels();

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
@@ -53,6 +53,14 @@ public interface ModelResourceManager {
     */
    void deleteResource(String modeluri) throws IOException;
 
+   /**
+    * Closes a resource, forgetting about its content and any current modification.
+    * Resource can be reopened later from its persisted state with a simple {@link #loadResource(String)} call.
+    *
+    * @param modeluri the URI of the model resource
+    */
+   void closeResource(String modeluri);
+
    CCommandExecutionResult execute(String modeluri, CCommand command) throws DecodingException;
 
    Optional<CCommandExecutionResult> undo(String modeluri);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
@@ -90,6 +90,7 @@ public class ModelServerRoutingV1 implements Routing {
       patch(ModelServerPathsV1.MODEL_BASE_PATH, this::setModel);
       delete(ModelServerPathsV1.MODEL_BASE_PATH, this::deleteModel);
 
+      post(ModelServerPathsV1.CLOSE, this::closeModel);
       patch(ModelServerPathsV1.EDIT, this::executeCommand);
       get(ModelServerPathsV1.UNDO, this::undoCommand);
       get(ModelServerPathsV1.REDO, this::redoCommand);
@@ -210,6 +211,12 @@ public class ModelServerRoutingV1 implements Routing {
    protected void deleteModel(final Context ctx) {
       getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
          param -> modelController.delete(ctx, param),
+         () -> missingParameter(ctx, MODEL_URI));
+   }
+
+   protected void closeModel(final Context ctx) {
+      getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
+         param -> modelController.close(ctx, param),
          () -> missingParameter(ctx, MODEL_URI));
    }
 

--- a/tests/org.eclipse.emfcloud.modelserver.client.tests/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.client.tests/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientTest.java
@@ -301,6 +301,24 @@ public class ModelServerClientTest {
    }
 
    @Test
+   public void close() throws ExecutionException, InterruptedException, MalformedURLException {
+      String modelUri = "SuperBrewer3000.coffee";
+      String closeUrl = baseHttpUrlBuilder
+         .addPathSegment(ModelServerPathsV1.CLOSE)
+         .addQueryParameter(ModelServerPathParametersV1.MODEL_URI, modelUri)
+         .build().toString();
+
+      interceptor.addRule()
+         .url(closeUrl)
+         .post()
+         .respond(Json.object(Json.prop(JsonResponseMember.TYPE, Json.text(JsonResponseType.SUCCESS))).toString());
+      ModelServerClient client = createClient();
+
+      final CompletableFuture<Response<Boolean>> f = client.close(modelUri);
+      assertThat(f.get().body(), equalTo(true));
+   }
+
+   @Test
    @SuppressWarnings({ "checkstyle:ThrowsCount" })
    public void create() throws EncodingException, ExecutionException, InterruptedException, MalformedURLException {
       final JsonNode expected = jsonCodec.encode(eClass);


### PR DESCRIPTION
Introducing a new endpoint to close the resource.
This is implemented by the ModelResourceManager.
Default implementation reloads the model immediately, but a lazy
implementation doesn't have to...

fixes #99