### PR TITLE
#115 : Introduce file watching concept

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Require-Bundle: com.fasterxml.jackson.core.jackson-core;bundle-version="[2.9.0,3
 Export-Package: org.eclipse.emfcloud.modelserver.emf.common,
  org.eclipse.emfcloud.modelserver.emf.common.codecs,
  org.eclipse.emfcloud.modelserver.emf.common.util,
+ org.eclipse.emfcloud.modelserver.emf.common.watchers,
  org.eclipse.emfcloud.modelserver.emf.configuration,
  org.eclipse.emfcloud.modelserver.emf.di,
  org.eclipse.emfcloud.modelserver.emf.launch

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -185,7 +185,7 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    }
 
    /**
-    * Watch for resource modifications
+    * Watch for resource modifications.
     *
     * @param resource the resource to watch for
     */

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -52,14 +52,13 @@ public class DefaultModelResourceManager implements ModelResourceManager {
 
    @Inject
    protected CommandCodec commandCodec;
-   @Inject
-   protected ModelWatchersManager watchersManager;
 
    @Inject
    protected final ServerConfiguration serverConfiguration;
 
    protected final Set<EPackageConfiguration> configurations;
    protected final AdapterFactory adapterFactory;
+   protected ModelWatchersManager watchersManager;
    protected final Map<URI, ResourceSet> resourceSets = Maps.newLinkedHashMap();
    protected final Map<ResourceSet, ModelServerEditingDomain> editingDomains = Maps.newLinkedHashMap();
 
@@ -67,11 +66,13 @@ public class DefaultModelResourceManager implements ModelResourceManager {
 
    @Inject
    public DefaultModelResourceManager(final Set<EPackageConfiguration> configurations,
-      final AdapterFactory adapterFactory, final ServerConfiguration serverConfiguration) {
+      final AdapterFactory adapterFactory, final ServerConfiguration serverConfiguration,
+      final ModelWatchersManager watchersManager) {
 
       this.configurations = Sets.newLinkedHashSet(configurations);
       this.adapterFactory = adapterFactory;
       this.serverConfiguration = serverConfiguration;
+      this.watchersManager = watchersManager;
       initialize();
    }
 
@@ -329,6 +330,7 @@ public class DefaultModelResourceManager implements ModelResourceManager {
       newResourceSet.getResources().add(resource);
       resource.getContents().add(model);
       resource.save(null);
+      watchResourceModifications(resource);
       createEditingDomain(newResourceSet);
    }
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
@@ -29,6 +29,13 @@ public interface ModelResourceManager {
 
    Optional<Resource> loadResource(String modeluri);
 
+   /**
+    * Watch for resource modifications (should be invoked just after loading)
+    *
+    * @param resource the resource to watch for
+    */
+   void watchResourceModifications(final Resource resource);
+
    <T extends EObject> Optional<T> loadModel(String modeluri, Class<T> clazz);
 
    boolean isResourceLoaded(String modeluri);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
@@ -30,11 +30,11 @@ public interface ModelResourceManager {
    Optional<Resource> loadResource(String modeluri);
 
    /**
-    * Watch for resource modifications (should be invoked just after loading)
+    * Watch for resource modifications (should be invoked just after loading).
     *
     * @param resource the resource to watch for
     */
-   void watchResourceModifications(final Resource resource);
+   void watchResourceModifications(Resource resource);
 
    <T extends EObject> Optional<T> loadModel(String modeluri, Class<T> clazz);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/RecordingModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/RecordingModelResourceManager.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.change.ChangeDescription;
 import org.eclipse.emf.ecore.change.util.ChangeRecorder;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatchersManager;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ChangePackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
@@ -34,8 +35,8 @@ public class RecordingModelResourceManager extends DefaultModelResourceManager {
    @Inject
    public RecordingModelResourceManager(final Set<EPackageConfiguration> configurations,
       final AdapterFactory adapterFactory,
-      final ServerConfiguration serverConfiguration) {
-      super(configurations, adapterFactory, serverConfiguration);
+      final ServerConfiguration serverConfiguration, final ModelWatchersManager watchersManager) {
+      super(configurations, adapterFactory, serverConfiguration, watchersManager);
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/AbstractModelWatcher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/AbstractModelWatcher.java
@@ -27,24 +27,24 @@ import com.google.inject.Inject;
  */
 public abstract class AbstractModelWatcher implements ModelWatcher, Runnable {
 
-   /** The thread running this watcher */
+   /** The thread running this watcher. */
    protected final Thread worker;
 
-   /** Whether still on watch */
-   protected boolean running = false;
+   /** Whether still on watch. */
+   protected boolean running;
 
-   /** The EMF resource */
+   /** The EMF resource. */
    protected Resource resource;
 
-   /** The EMF resource */
+   /** The EMF resource. */
    @Inject
    protected ReconcilingStrategy strategy;
 
-   /** the adapter on resource to stop the watcher */
+   /** The adapter on resource to stop the watcher. */
    private AdapterImpl resourceAdapter;
 
    /**
-    * Reconcile the model applying the injected strategy
+    * Reconcile the model applying the injected strategy.
     *
     * @param resource
     */
@@ -79,7 +79,7 @@ public abstract class AbstractModelWatcher implements ModelWatcher, Runnable {
    }
 
    /**
-    * Add an adapter to the resource to stop watching the resource on closure
+    * Add an adapter to the resource to stop watching the resource on closure.
     */
    private void addStopAdapter() {
       // stop watcher automatically when resource is unloaded
@@ -98,7 +98,7 @@ public abstract class AbstractModelWatcher implements ModelWatcher, Runnable {
    }
 
    /**
-    * Tell this watcher to stop polling
+    * Tell this watcher to stop polling.
     */
    public void stop() {
       this.running = false;

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/AbstractModelWatcher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/AbstractModelWatcher.java
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.watchers;
+
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.impl.AdapterImpl;
+import org.eclipse.emf.ecore.resource.Resource;
+
+import com.google.inject.Inject;
+
+/**
+ * Watches for changes on model resource to adopt a strategy to update models.
+ * This abstract implementation provides basic functionalities to poll for resource modifications in a {@link Runnable}
+ * loop.
+ *
+ * @author vhemery
+ */
+public abstract class AbstractModelWatcher implements ModelWatcher, Runnable {
+
+   /** The thread running this watcher */
+   private final Thread worker;
+
+   /** Whether still on watch */
+   protected boolean running = false;
+
+   /** The EMF resource */
+   protected Resource resource;
+
+   /** The EMF resource */
+   @Inject
+   protected ReconcilingStrategy strategy;
+
+   /**
+    * Reconcile the model applying the injected strategy
+    *
+    * @param resource
+    */
+   public void reconcile(final Resource resource) {
+      strategy.reconcileModel(resource);
+   }
+
+   /**
+    * Creates a new watcher to listen to model resource changes.
+    */
+   protected AbstractModelWatcher() {
+      this.worker = new Thread(this);
+      this.worker.setDaemon(true);
+   }
+
+   @Override
+   public void watch(final Resource resource) {
+      this.resource = resource;
+      this.running = true;
+      this.worker.start();
+      addStopAdapter();
+   }
+
+   /**
+    * Add an adapter to the resource to stop watching the resource on closure
+    */
+   private void addStopAdapter() {
+      // stop watcher automatically when resource is unloaded
+      resource.eAdapters().add(new AdapterImpl() {
+         @Override
+         public void notifyChanged(final Notification msg) {
+            if (resource.equals(msg.getNotifier())
+               && Resource.RESOURCE__IS_LOADED == msg.getFeatureID(Resource.class) && !msg.getNewBooleanValue()) {
+               // resource is now unloaded, stop watching
+               AbstractModelWatcher.this.stop();
+               resource.eAdapters().remove(this);
+            }
+         }
+      });
+   }
+
+   /**
+    * Tell this watcher to stop polling
+    */
+   public void stop() {
+      this.running = false;
+      this.worker.interrupt();
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/AbstractModelWatcher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/AbstractModelWatcher.java
@@ -28,7 +28,7 @@ import com.google.inject.Inject;
 public abstract class AbstractModelWatcher implements ModelWatcher, Runnable {
 
    /** The thread running this watcher */
-   private final Thread worker;
+   protected final Thread worker;
 
    /** Whether still on watch */
    protected boolean running = false;

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/DIModelWatchersManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/DIModelWatchersManager.java
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.watchers;
+
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.log4j.Logger;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatcher.Factory;
+
+import com.google.inject.Inject;
+
+/**
+ * Manages the {@link ModelWatcher} instances for loaded resources, relying on injected factories.
+ *
+ * @author vhemery
+ */
+public class DIModelWatchersManager implements ModelWatchersManager {
+
+   /** logger */
+   protected static final Logger LOG = Logger.getLogger(DIModelWatchersManager.class.getSimpleName());
+
+   /** the registered {@link ModelWatcher} factories */
+   @Inject(optional = true)
+   private final Set<ModelWatcher.Factory> watcherFactories = Collections.emptySet();
+
+   @Override
+   public void watch(final Resource resource) {
+      Optional<Factory> supportingFactory = watcherFactories.stream().filter(f -> f.handles(resource)).findFirst();
+      supportingFactory.ifPresentOrElse(f -> {
+         ModelWatcher watcher = f.createWatcher(resource);
+         watcher.watch(resource);
+      }, () -> {
+         // just trace it
+         String modelUri = resource.getURI().toString();
+         LOG.trace(MessageFormat.format("No model watcher could be constructed for resource {0}", modelUri));
+      });
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/DIModelWatchersManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/DIModelWatchersManager.java
@@ -28,10 +28,10 @@ import com.google.inject.Inject;
  */
 public class DIModelWatchersManager implements ModelWatchersManager {
 
-   /** logger */
+   /** Logger. */
    protected static final Logger LOG = Logger.getLogger(DIModelWatchersManager.class.getSimpleName());
 
-   /** the registered {@link ModelWatcher} factories */
+   /** The registered {@link ModelWatcher} factories. */
    @Inject(optional = true)
    private final Set<ModelWatcher.Factory> watcherFactories = Collections.emptySet();
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcher.java
@@ -1,0 +1,149 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.watchers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.text.MessageFormat;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+/**
+ * Watches for changes on model files to adopt a strategy to update models
+ *
+ * @author vhemery
+ */
+public class FileModelWatcher extends AbstractModelWatcher {
+
+   /**
+    * The factory for {@link FileModelWatcher}
+    */
+   public static class Factory implements ModelWatcher.Factory {
+
+      @Inject
+      private Injector injector;
+
+      @Override
+      public boolean handles(final Resource resource) {
+         // we only support file resources
+         URI uri = resource.getURI();
+         uri = resource.getResourceSet().getURIConverter().normalize(uri);
+         File file = toFile(uri);
+         return file != null && file.exists();
+      }
+
+      @Override
+      public ModelWatcher createWatcher(final Resource resource) {
+         return injector.getInstance(FileModelWatcher.class);
+      }
+
+   }
+
+   /** logger */
+   protected static final Logger LOG = Logger.getLogger(FileModelWatcher.class.getSimpleName());
+
+   /** The file to watch for */
+   private File fileToWatch;
+
+   /**
+    * Creates a new watcher to listen to model file changes.
+    */
+   public FileModelWatcher() {
+      super();
+   }
+
+   @Override
+   public void watch(final Resource resource) {
+      URI uri = resource.getURI();
+      uri = resource.getResourceSet().getURIConverter().normalize(uri);
+      File file = toFile(uri);
+      if (file != null) {
+         this.fileToWatch = file;
+         super.watch(resource);
+      }
+   }
+
+   /**
+    * Convert a uri to a concrete file
+    *
+    * @param uri a uri
+    * @return corresponding file or <code>null</code>
+    */
+   private static File toFile(final URI uri) {
+      File file = null;
+      if (uri.isPlatformResource()) {
+         IPath path = org.eclipse.core.runtime.Path.fromPortableString(uri.toPlatformString(true));
+         IResource res = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
+         if (res != null) {
+            file = res.getLocation().toFile();
+         }
+      } else if (uri.isFile()) {
+         String path = uri.toFileString();
+         file = new File(path);
+      }
+      return file;
+   }
+
+   @Override
+   public void run() {
+      try (WatchService ws = FileSystems.getDefault().newWatchService()) {
+         Path path = Paths.get(fileToWatch.getParent());
+         path.register(ws, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_DELETE);
+         while (running) {
+            WatchKey key = ws.take();
+            /*
+             * Sleep to prevent receiving two separate ENTRY_MODIFY events:
+             * one for file modified and one for timestamp updated
+             * Instead, receive one event with two counts.
+             */
+            Thread.sleep(50);
+            List<WatchEvent<?>> events = key.pollEvents();
+            for (WatchEvent<?> event : events) {
+               Object ctx = event.context();
+               boolean changeOnWatchedFile = ctx instanceof Path
+                  && ((Path) ctx).getFileName().toString().equals(fileToWatch.getName());
+               if (changeOnWatchedFile) {
+                  if (StandardWatchEventKinds.ENTRY_DELETE.equals(event.kind())
+                     || fileToWatch.lastModified() > resource.getTimeStamp()) {
+                     // reconcile model on file change
+                     reconcile(this.resource);
+                  }
+               }
+            }
+            if (!key.reset()) {
+               running = false;
+            }
+         }
+      } catch (IOException e) {
+         String msg = MessageFormat.format("Failed while watching for file {0}", this.fileToWatch.toURI());
+         LOG.error(msg, e);
+      } catch (InterruptedException e) {
+         // assume it is to stop, nothing to do
+      }
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcher.java
@@ -113,6 +113,12 @@ public class FileModelWatcher extends AbstractModelWatcher {
       try (WatchService ws = FileSystems.getDefault().newWatchService()) {
          Path path = Paths.get(fileToWatch.getParent());
          path.register(ws, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_DELETE);
+         // watch service may have been initialized late, after a first update. Check it once...
+         if (!fileToWatch.exists() || fileToWatch.lastModified() > resource.getTimeStamp()) {
+            // reconcile model on file change
+            reconcile(this.resource);
+         }
+         // run loop
          while (running) {
             WatchKey key = ws.take();
             /*

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatcher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatcher.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.watchers;
+
+import org.eclipse.emf.ecore.resource.Resource;
+
+/**
+ * Watches for changes on model resources to adopt a strategy to update models
+ *
+ * @author vhemery
+ */
+public interface ModelWatcher {
+
+   /**
+    * Factory to create a {@link ModelWatcher} from a supported {@link Resource}
+    */
+   public interface Factory {
+
+      /**
+       * Test whether factory can handle this model resource (test often based on URI)
+       *
+       * @param resource the resource to create {@link ModelWatcher} for
+       * @return true when resource is supported
+       */
+      boolean handles(Resource resource);
+
+      /**
+       * Create or return a {@link ModelWatcher} instance for this model resource.<br/>
+       * (implementation may choose to create a new instance each time, or reuse an existing instance when relevant)
+       *
+       * @param resource the resource to create {@link ModelWatcher} for
+       * @return created instance
+       */
+      ModelWatcher createWatcher(Resource resource);
+
+   }
+
+   /**
+    * Watch for modifications on the model resource
+    *
+    * @param resource the model resource to watch for
+    */
+   void watch(Resource resource);
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatcher.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatcher.java
@@ -13,19 +13,19 @@ package org.eclipse.emfcloud.modelserver.emf.common.watchers;
 import org.eclipse.emf.ecore.resource.Resource;
 
 /**
- * Watches for changes on model resources to adopt a strategy to update models
+ * Watches for changes on model resources to adopt a strategy to update models.
  *
  * @author vhemery
  */
 public interface ModelWatcher {
 
    /**
-    * Factory to create a {@link ModelWatcher} from a supported {@link Resource}
+    * Factory to create a {@link ModelWatcher} from a supported {@link Resource}.
     */
    public interface Factory {
 
       /**
-       * Test whether factory can handle this model resource (test often based on URI)
+       * Test whether factory can handle this model resource (test often based on URI).
        *
        * @param resource the resource to create {@link ModelWatcher} for
        * @return true when resource is supported
@@ -44,7 +44,7 @@ public interface ModelWatcher {
    }
 
    /**
-    * Watch for modifications on the model resource
+    * Watch for modifications on the model resource.
     *
     * @param resource the model resource to watch for
     */

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatchersManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatchersManager.java
@@ -20,7 +20,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 public interface ModelWatchersManager {
 
    /**
-    * Watch for modifications on the model resource
+    * Watch for modifications on the model resource.
     *
     * @param resource the model resource to watch for
     */

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatchersManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ModelWatchersManager.java
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.watchers;
+
+import org.eclipse.emf.ecore.resource.Resource;
+
+/**
+ * Manages the {@link ModelWatcher} instances for loaded resources.
+ *
+ * @author vhemery
+ */
+public interface ModelWatchersManager {
+
+   /**
+    * Watch for modifications on the model resource
+    *
+    * @param resource the model resource to watch for
+    */
+   void watch(Resource resource);
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ReconcilingStrategy.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ReconcilingStrategy.java
@@ -38,15 +38,15 @@ public interface ReconcilingStrategy {
     *
     * @author vhemery
     */
-   public static class AlwaysReload implements ReconcilingStrategy {
+   class AlwaysReload implements ReconcilingStrategy {
 
-      /** the injected model repository which can be used to reload models */
+      /** The injected model repository which can be used to reload models. */
       @Inject
-      ModelRepository repository;
+      private ModelRepository repository;
 
-      /** the session controller to inform about model reconciliation */
+      /** The session controller to inform about model reconciliation. */
       @Inject
-      SessionController sessionController;
+      private SessionController sessionController;
 
       /**
        * Reconcile by reloading the model resource.
@@ -84,10 +84,10 @@ public interface ReconcilingStrategy {
     *
     * @author vhemery
     */
-   public static class Ignore implements ReconcilingStrategy {
+   class Ignore implements ReconcilingStrategy {
 
       /**
-       * Reconcile by doing nothing
+       * Reconcile by doing nothing.
        *
        * @param modelResource the model resource to reconcile
        */

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ReconcilingStrategy.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/ReconcilingStrategy.java
@@ -1,0 +1,101 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.watchers;
+
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
+import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
+
+import com.google.inject.Inject;
+
+/**
+ * A strategy for reconciling model resources with the underlying persistence.
+ *
+ * @author vhemery
+ */
+public interface ReconcilingStrategy {
+
+   /**
+    * Reconcile the model resource with the underlying persistence when a divergence occurs.
+    * This does not necessarily reload the model resource, depending on the adopted strategy.
+    *
+    * @param modelResource the model resource to reconcile
+    */
+   void reconcileModel(Resource modelResource);
+
+   /**
+    * A strategy to always reload the model from persisted resource, loosing local modifications.
+    *
+    * @author vhemery
+    */
+   public static class AlwaysReload implements ReconcilingStrategy {
+
+      /** the injected model repository which can be used to reload models */
+      @Inject
+      ModelRepository repository;
+
+      /** the session controller to inform about model reconciliation */
+      @Inject
+      SessionController sessionController;
+
+      /**
+       * Reconcile by reloading the model resource.
+       *
+       * @param modelResource the model resource to reconcile
+       */
+      @Override
+      public void reconcileModel(final Resource modelResource) {
+         // close and reload the resource
+         String modelUri = modelResource.getURI().toString();
+         repository.closeModel(modelUri);
+         boolean reloaded = false;
+         if (repository.hasModel(modelUri)) {
+            Optional<Resource> loadedResource = repository.loadResource(modelUri);
+            reloaded = loadedResource.isPresent();
+            if (!reloaded) {
+               // incorrect load: model has probably been corrupted, re-close just in case...
+               repository.closeModel(modelUri);
+            }
+         }
+         // dispatch the message
+         if (reloaded) {
+            // model was reloaded, trigger a full updated
+            sessionController.modelUpdated(modelUri);
+         } else {
+            // model was deleted, trigger a closed
+            sessionController.modelClosed(modelUri);
+         }
+      }
+
+   }
+
+   /**
+    * A strategy to always ignore persisted resource modifications and keep the loaded model as is.
+    *
+    * @author vhemery
+    */
+   public static class Ignore implements ReconcilingStrategy {
+
+      /**
+       * Reconcile by doing nothing
+       *
+       * @param modelResource the model resource to reconcile
+       */
+      @Override
+      public void reconcileModel(final Resource modelResource) {
+         // do absolutely nothing!
+      }
+
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
@@ -41,6 +41,10 @@ import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
 import org.eclipse.emfcloud.modelserver.emf.common.UriHelper;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.DICodecsManager;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.DIModelWatchersManager;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatcher;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatchersManager;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ReconcilingStrategy;
 import org.eclipse.emfcloud.modelserver.emf.configuration.DefaultServerConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.FacetConfig;
@@ -71,6 +75,8 @@ public class DefaultModelServerModule extends ModelServerModule {
       bind(ServerController.class).to(bindServerController()).in(Singleton.class);
       bind(CommandCodec.class).to(bindCommandCodec()).in(Singleton.class);
       bind(ModelResourceManager.class).to(bindModelResourceManager()).in(Singleton.class);
+      bind(ModelWatchersManager.class).to(bindModelWatchersManager()).in(Singleton.class);
+      bind(ReconcilingStrategy.class).to(bindReconcilingStrategy()).in(Singleton.class);
       bind(CodecsManager.class).to(bindCodecsManager()).in(Singleton.class);
       bind(ModelValidator.class).to(bindModelValidator()).in(Singleton.class);
       bind(FacetConfig.class).to(bindFacetConfig()).in(Singleton.class);
@@ -111,6 +117,14 @@ public class DefaultModelServerModule extends ModelServerModule {
 
    protected Class<? extends ModelResourceManager> bindModelResourceManager() {
       return RecordingModelResourceManager.class;
+   }
+
+   protected Class<? extends ModelWatchersManager> bindModelWatchersManager() {
+      return DIModelWatchersManager.class;
+   }
+
+   protected Class<? extends ReconcilingStrategy> bindReconcilingStrategy() {
+      return ReconcilingStrategy.AlwaysReload.class;
    }
 
    @Override
@@ -181,6 +195,7 @@ public class DefaultModelServerModule extends ModelServerModule {
       configure(MapBinding.create(EntryPointType.class, AppEntryPoint.class), this::configureAppEntryPoints);
       configure(MapBinding.create(String.class, Codec.class), this::configureCodecs);
       configure(MapBinding.create(String.class, CommandContribution.class), this::configureCommandCodecs);
+      configure(MultiBinding.create(ModelWatcher.Factory.class), this::configureModelWatcherFactories);
    }
 
    protected void configureRoutings(final MultiBinding<Routing> binding) {
@@ -197,5 +212,9 @@ public class DefaultModelServerModule extends ModelServerModule {
 
    protected ObjectMapper provideObjectMapper() {
       return ProviderDefaults.provideObjectMapper();
+   }
+
+   protected void configureModelWatcherFactories(final MultiBinding<ModelWatcher.Factory> binding) {
+      binding.addAll(MultiBindingDefaults.DEFAULT_MODEL_WATCHER_FACTORIES);
    }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/MultiBindingDefaults.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/MultiBindingDefaults.java
@@ -28,6 +28,8 @@ import org.eclipse.emfcloud.modelserver.edit.command.SetCommandContribution;
 import org.eclipse.emfcloud.modelserver.edit.command.UpdateModelCommandContribution;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelServerRoutingV1;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.FileModelWatcher;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatcher;
 import org.eclipse.emfcloud.modelserver.emf.configuration.CommandPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EcorePackageConfiguration;
@@ -56,4 +58,7 @@ public final class MultiBindingDefaults {
       EMFCommandType.REMOVE, RemoveCommandContribution.class,
       EMFCommandType.COMPOUND, CompoundCommandContribution.class,
       UpdateModelCommandContribution.TYPE, UpdateModelCommandContribution.class);
+
+   public static final List<Class<? extends ModelWatcher.Factory>> DEFAULT_MODEL_WATCHER_FACTORIES = List.of(
+      FileModelWatcher.Factory.class);
 }

--- a/releng/org.eclipse.emfcloud.modelserver.releng.target/targetplatform.target
+++ b/releng/org.eclipse.emfcloud.modelserver.releng.target/targetplatform.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="EMF.cloud Model Server Targetplatform" sequenceNumber="1631195344">
+<target name="EMF.cloud Model Server Targetplatform" sequenceNumber="1636115478">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.platform.feature.group" version="4.20.0.v20210611-1600"/>
@@ -33,8 +33,8 @@
       <repository location="https://download.eclipse.org/emfcloud/emfjson-jackson/p2/nightly/1.3/1.3.1.202109010859"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jetty.websocket.server" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.43.v20210629/"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.4.44.v20210927"/>
+      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927/"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.emfcloud.modelserver.releng.target/targetplatform.tpd
+++ b/releng/org.eclipse.emfcloud.modelserver.releng.target/targetplatform.tpd
@@ -30,6 +30,6 @@ location "https://download.eclipse.org/emfcloud/emfjson-jackson/p2/nightly/1.3/1
 	org.eclipse.emfcloud.emfjson-jackson lazy
 }
 
-location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.43.v20210629/" {
+location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927/" {
 	org.eclipse.jetty.websocket.server
 }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/DefaultModelResourceManagerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/DefaultModelResourceManagerTest.java
@@ -34,6 +34,7 @@ import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelResourceManager;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatchersManager;
 import org.eclipse.emfcloud.modelserver.emf.configuration.CommandPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EcorePackageConfiguration;
@@ -53,6 +54,9 @@ import com.google.inject.multibindings.Multibinder;
 public class DefaultModelResourceManagerTest extends AbstractResourceTest {
 
    private static ModelResourceManager modelResourceManager;
+
+   @Mock
+   private ModelWatchersManager watchersManager;
 
    @Mock
    private CommandCodec commandCodec;
@@ -83,6 +87,7 @@ public class DefaultModelResourceManagerTest extends AbstractResourceTest {
 
             bind(ServerConfiguration.class).toInstance(serverConfig);
             bind(CommandCodec.class).toInstance(commandCodec);
+            bind(ModelWatchersManager.class).toInstance(watchersManager);
             bind(AdapterFactory.class).toInstance(new EcoreAdapterFactory());
          }
       }).getInstance(DefaultModelResourceManager.class);

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
@@ -1,0 +1,199 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.watchers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EModelElement;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
+import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
+import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
+import org.eclipse.emfcloud.modelserver.emf.AbstractResourceTest;
+import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelRepository;
+import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
+import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
+import org.eclipse.emfcloud.modelserver.emf.configuration.EcorePackageConfiguration;
+import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+
+/**
+ * This is an integration test to ensure that the whole model watcher mechanism works with :
+ * <ul>
+ * <li>{@link DIModelWatchersManager}</li>
+ * <li>{@link FileModelWatcher}</li>
+ * <li>{@link ReconcilingStrategy.AlwaysReload}</li>
+ * <li>{@link DefaultModelResourceManager}</li>
+ * <li>{@link DefaultModelRepository}</li>
+ * </ul>
+ *
+ * @author vhemery
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FileModelWatcherIntegrationTest extends AbstractResourceTest {
+
+   private static ModelResourceManager modelResourceManager;
+
+   @Mock
+   private ServerConfiguration serverConfig;
+   @Mock
+   private CommandCodec commandCodec;
+
+   @Mock
+   private SessionController session;
+
+   public FileModelWatcherIntegrationTest() {
+      super();
+   }
+
+   @Before
+   public void beforeTests() throws DecodingException {
+      when(serverConfig.getWorkspaceRootURI())
+         .thenReturn(URI.createFileURI(getCWD().getAbsolutePath() + "/" + RESOURCE_PATH));
+      Injector injector = Guice.createInjector(new AbstractModule() {
+
+         private Multibinder<ModelWatcher.Factory> watcherFactoryBinder;
+         private Multibinder<EPackageConfiguration> ePackageConfigurationBinder;
+
+         @Override
+         protected void configure() {
+            ePackageConfigurationBinder = Multibinder.newSetBinder(binder(), EPackageConfiguration.class);
+            ePackageConfigurationBinder.addBinding().to(EcorePackageConfiguration.class);
+
+            watcherFactoryBinder = Multibinder.newSetBinder(binder(), ModelWatcher.Factory.class);
+            watcherFactoryBinder.addBinding().to(FileModelWatcher.Factory.class);
+
+            bind(ServerConfiguration.class).toInstance(serverConfig);
+            bind(CommandCodec.class).toInstance(commandCodec);
+            bind(SessionController.class).toInstance(session);
+            bind(AdapterFactory.class).toInstance(new EcoreAdapterFactory());
+
+            // for the reconciling strategy to work, we need the actual ModelRepository and ModelResourceManager
+            bind(ReconcilingStrategy.class).to(ReconcilingStrategy.AlwaysReload.class).in(Singleton.class);
+            bind(ModelWatchersManager.class).to(DIModelWatchersManager.class).in(Singleton.class);
+            bind(ModelRepository.class).to(DefaultModelRepository.class).in(Singleton.class);
+            bind(ModelResourceManager.class).to(DefaultModelResourceManager.class).in(Singleton.class);
+         }
+      });
+      modelResourceManager = injector.getInstance(ModelResourceManager.class);
+
+   }
+
+   // Test framework
+   private static File getCWD() { return new File(System.getProperty("user.dir")); }
+
+   private static String adaptModelUri(final String modelUri) {
+      return URI.createFileURI(getCWD().getAbsolutePath() + "/" + RESOURCE_PATH + modelUri).toString();
+   }
+
+   /**
+    * Convert a uri to a concrete file
+    *
+    * @param uri a uri
+    * @return corresponding file or <code>null</code>
+    */
+   private static File toFile(final URI uri) {
+      File file = null;
+      if (uri.isPlatformResource()) {
+         IPath path = org.eclipse.core.runtime.Path.fromPortableString(uri.toPlatformString(true));
+         IResource res = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
+         if (res != null) {
+            file = res.getLocation().toFile();
+         }
+      } else if (uri.isFile()) {
+         String path = uri.toFileString();
+         file = new File(path);
+      }
+      return file;
+   }
+
+   @Test
+   public void testReconciliation() throws IOException {
+      String modelUri = adaptModelUri("TestReconcile.ecore").toString();
+      // initialize the resource with an EClass
+      modelResourceManager.addResource(modelUri, EcoreFactory.eINSTANCE.createEClass());
+      Resource outsiderResource = loadResource("TestReconcile.ecore");
+      try {
+         // load initial resource from model server
+         Optional<EModelElement> loadedModelElement = modelResourceManager.loadModel(modelUri, EModelElement.class);
+         assertTrue(loadedModelElement.filter(EClass.class::isInstance).isPresent());
+
+         // check both resources are different and listen to the model server resource
+         Resource modelServerResource = loadedModelElement.get().eResource();
+         assertNotNull(modelServerResource);
+         assertNotEquals(modelServerResource, outsiderResource);
+         assertEquals(toFile(modelServerResource.getURI()).getAbsoluteFile(),
+            toFile(outsiderResource.getURI()).getAbsoluteFile());
+
+         // replace resource content with an EPackage, outside of ModelServer framework
+         outsiderResource.getContents().replaceAll(c -> EcoreFactory.eINSTANCE.createEPackage());
+         outsiderResource.save(Collections.emptyMap());
+
+         // reload and check the model server resource has not yet been updated
+         loadedModelElement = modelResourceManager.loadModel(modelUri, EModelElement.class);
+         assertFalse(loadedModelElement.filter(EPackage.class::isInstance).isPresent());
+
+         // recheck after reconciliation has occurred
+         Thread.sleep(1000L);
+         loadedModelElement = modelResourceManager.loadModel(modelUri, EModelElement.class);
+         assertTrue(loadedModelElement.filter(EPackage.class::isInstance).isPresent());
+
+         // delete resource
+         outsiderResource.delete(Collections.emptyMap());
+
+         // reload and check the model server resource has not yet been deleted too
+         loadedModelElement = modelResourceManager.loadModel(modelUri, EModelElement.class);
+         assertTrue(loadedModelElement.isPresent());
+
+         // recheck after reconciliation has occurred
+         Thread.sleep(1000L);
+         loadedModelElement = modelResourceManager.loadModel(modelUri, EModelElement.class);
+         assertFalse(loadedModelElement.isPresent());
+      } catch (InterruptedException e) {
+         fail(e.getMessage());
+      } finally {
+         // force resource deletion to leave resource clean
+         outsiderResource.delete(Collections.emptyMap());
+      }
+   }
+}

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
@@ -61,7 +61,8 @@ import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 
 /**
- * This is an integration test to ensure that the whole model watcher mechanism works with :
+ * This is an integration test to ensure that the whole model watcher mechanism works.
+ * Integration test involves :
  * <ul>
  * <li>{@link DIModelWatchersManager}</li>
  * <li>{@link FileModelWatcher}</li>
@@ -75,7 +76,7 @@ import com.google.inject.multibindings.Multibinder;
 @RunWith(MockitoJUnitRunner.class)
 public class FileModelWatcherIntegrationTest extends AbstractResourceTest {
 
-   /** tells us whether expected reconciliations occurred */
+   /** Tells us whether expected reconciliations occurred. */
    private static AtomicReference<CountDownLatch> latch = new AtomicReference<>();
 
    /**
@@ -146,7 +147,7 @@ public class FileModelWatcherIntegrationTest extends AbstractResourceTest {
    }
 
    /**
-    * Convert a uri to a concrete file
+    * Converts a uri to a concrete file.
     *
     * @param uri a uri
     * @return corresponding file or <code>null</code>


### PR DESCRIPTION
Adding ModelWatchers, which must invoked by ModelResourceManager after
loading a resource.
On a divergence, a ModelWatcher must ask the active ReconcilingStrategy
to solve the issue. (2 are contributed)
The default FileModelWatcher implementation is contributed, listening at
file changes, but other implementations are possible for different
protocols.

Fixes #115