### PR TITLE
#140 Update to emfcloud.checkstyle 0.1.0-RC02

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,8 @@ All involved code must adhere to the provided codestyle and checkstyle settings.
 - Install the Eclipse Checkstyle Plug-in via its update site `https://checkstyle.org/eclipse-cs/#!/install`.
 
 #### Configure Checkstyle
-To configure Checkstyle for the new project right click on the project, choose `Checkstyle > Configure project(s) from blueprint...` and select `org.eclipse.emfcloud.modelserver.common` as blueprint project.
+This project uses the common checkstyle ruleset from EMF.cloud. Please follow the [instructions for usage in Eclipse](https://github.com/eclipse-emfcloud/emfcloud/tree/master/codestyle#usage-in-eclipse-ide) to configure this ruleset for a new project.
+To configure Checkstyle for a new project in the same workspace your can also right click on the project, choose `Checkstyle > Configure project(s) from blueprint...` and select `org.eclipse.emfcloud.modelserver.common` as blueprint project.
 Run `Checkstyle > Check Code with Checkstyle` to make sure Checkstyle is activated correctly.
 
 #### Import Existing Projects

--- a/bundles/.project
+++ b/bundles/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emfcloud.modelserver.bundles.parent</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.eclipse.emfcloud.modelserver.client/.checkstyle
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/bundles/org.eclipse.emfcloud.modelserver.common/.checkstyle
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/bundles/org.eclipse.emfcloud.modelserver.edit/.checkstyle
+++ b/bundles/org.eclipse.emfcloud.modelserver.edit/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/bundles/org.eclipse.emfcloud.modelserver.edit/.project
+++ b/bundles/org.eclipse.emfcloud.modelserver.edit/.project
@@ -21,12 +21,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/bundles/org.eclipse.emfcloud.modelserver.edit/.project
+++ b/bundles/org.eclipse.emfcloud.modelserver.edit/.project
@@ -21,12 +21,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/.checkstyle
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/bundles/org.eclipse.emfcloud.modelserver.lib/.checkstyle
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/bundles/org.eclipse.emfcloud.modelserver.lib/.classpath
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/.classpath
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/websocket-api-9.4.43.v20210629.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/websocket-servlet-9.4.43.v20210629.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>
@@ -15,5 +13,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/kotlin-stdlib-common-1.4.10.jar" sourcepath="lib/kotlin-stdlib-common-1.4.10-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okhttp-4.9.0.jar" sourcepath="lib/okhttp-4.9.0-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okio-2.10.0.jar" sourcepath="lib/okio-2.10.0-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/websocket-api-9.4.43.v20210629.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/websocket-servlet-9.4.43.v20210629.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.eclipse.emfcloud.modelserver.lib/.project
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/.project
@@ -21,12 +21,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/bundles/org.eclipse.emfcloud.modelserver.lib/.project
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/.project
@@ -25,10 +25,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/examples/.project
+++ b/examples/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emfcloud.modelserver.examples.parent</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/examples/.settings/org.eclipse.core.resources.prefs
+++ b/examples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/.settings/org.eclipse.m2e.core.prefs
+++ b/examples/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/examples/org.eclipse.emfcloud.modelserver.coffee.model/.checkstyle
+++ b/examples/org.eclipse.emfcloud.modelserver.coffee.model/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/examples/org.eclipse.emfcloud.modelserver.example/.checkstyle
+++ b/examples/org.eclipse.emfcloud.modelserver.example/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/features/.project
+++ b/features/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emfcloud.modelserver.features.parent</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/features/.settings/org.eclipse.core.resources.prefs
+++ b/features/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/.settings/org.eclipse.m2e.core.prefs
+++ b/features/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
 		<maven.compiler.version>3.8.1</maven.compiler.version>
 		<maven.clean.version>3.1.0</maven.clean.version>
 		<maven.checkstyle.version>3.1.1</maven.checkstyle.version>
-		<puppycrawl.checkstyle.version>8.39</puppycrawl.checkstyle.version>
-		<emfcloud.checkstyle.version>0.1.0-RC1</emfcloud.checkstyle.version>
+		<puppycrawl.checkstyle.version>8.44</puppycrawl.checkstyle.version>
+		<emfcloud.checkstyle.version>0.1.0-SNAPSHOT</emfcloud.checkstyle.version>
 		<maven.resources.version>3.2.0</maven.resources.version>
 		<maven.surefire.version>3.0.0-M5</maven.surefire.version>
 		<maven.failsafe.version>3.0.0-M5</maven.failsafe.version>
@@ -104,7 +104,7 @@
 		<mockito.core.version>2.23.0</mockito.core.version>
 		<hamcrest.core.version>1.3</hamcrest.core.version>
 		<maven.jar.version>3.2.0</maven.jar.version>
-		<maven.dependency.version>3.1.2</maven.dependency.version>
+		<maven.dependency.version>3.2.0</maven.dependency.version>
 
 		<!-- External Dependency Versions: Versions of dependencies that are not 
 			available via target platform. -->
@@ -123,6 +123,14 @@
 		<nexus.maven.version>1.6.8</nexus.maven.version>
 		<maven.gpg.version>1.6</maven.gpg.version>
 	</properties>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>sonatype</id>
+			<name>Sonatype</name>
+			<url>https://oss.sonatype.org/content/groups/public</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>
@@ -152,7 +160,7 @@
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>${maven.checkstyle.version}</version>
 				<configuration>
-					<configLocation>emfcloud-checkstyle.xml</configLocation>
+					<configLocation>emfcloud-checkstyle-8.44.xml</configLocation>
 					<consoleOutput>true</consoleOutput>
 
 				</configuration>

--- a/releng/.project
+++ b/releng/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emfcloud.modelserver.releng.parent</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/releng/.settings/org.eclipse.core.resources.prefs
+++ b/releng/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/.settings/org.eclipse.m2e.core.prefs
+++ b/releng/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/releng/org.eclipse.emfcloud.modelserver.codecoverage/.checkstyle
+++ b/releng/org.eclipse.emfcloud.modelserver.codecoverage/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/tests/.project
+++ b/tests/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emfcloud.modelserver.tests.parent</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/.settings/org.eclipse.m2e.core.prefs
+++ b/tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/tests/org.eclipse.emfcloud.modelserver.client.tests/.checkstyle
+++ b/tests/org.eclipse.emfcloud.modelserver.client.tests/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMFcloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/tortmayr/issues/19/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMFcloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/tests/org.eclipse.emfcloud.modelserver.client.tests/.classpath
+++ b/tests/org.eclipse.emfcloud.modelserver.client.tests/.classpath
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src/">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/org.eclipse.emfcloud.modelserver.client.tests/.project
+++ b/tests/org.eclipse.emfcloud.modelserver.client.tests/.project
@@ -25,8 +25,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>

--- a/tests/org.eclipse.emfcloud.modelserver.common.tests/.checkstyle
+++ b/tests/org.eclipse.emfcloud.modelserver.common.tests/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/tests/org.eclipse.emfcloud.modelserver.common.tests/.classpath
+++ b/tests/org.eclipse.emfcloud.modelserver.common.tests/.classpath
@@ -11,5 +11,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/org.eclipse.emfcloud.modelserver.common.tests/.project
+++ b/tests/org.eclipse.emfcloud.modelserver.common.tests/.project
@@ -25,8 +25,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>

--- a/tests/org.eclipse.emfcloud.modelserver.edit.tests/.checkstyle
+++ b/tests/org.eclipse.emfcloud.modelserver.edit.tests/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/tests/org.eclipse.emfcloud.modelserver.edit.tests/.classpath
+++ b/tests/org.eclipse.emfcloud.modelserver.edit.tests/.classpath
@@ -11,5 +11,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/org.eclipse.emfcloud.modelserver.edit.tests/.project
+++ b/tests/org.eclipse.emfcloud.modelserver.edit.tests/.project
@@ -25,8 +25,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/.checkstyle
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/.classpath
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/.classpath
@@ -11,10 +11,10 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-    <classpathentry kind="src" path="src-gen">
-      <attributes>
-         <attribute name="test" value="true"/>
-      </attributes>
-    </classpathentry>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src-gen">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/.project
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/.project
@@ -25,8 +25,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>

--- a/tests/org.eclipse.emfcloud.modelserver.tests/.checkstyle
+++ b/tests/org.eclipse.emfcloud.modelserver.tests/.checkstyle
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
-  <local-check-config name="EMF.cloud Checkstyle" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle.xml" type="remote" description="The central checkstyle configuration for emfcloud">
-    <additional-data name="cache-props-file-location" value="EMFcloud Checkstyle_1618908540765_cache.properties"/>
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="EMF.cloud Checkstyle (8.39)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.39.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.39">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.39)_1638214328569_cache.xml"/>
     <additional-data name="cache-file" value="true"/>
-    <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="all" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
+  <local-check-config name="EMF.cloud Checkstyle (8.44)" location="https://raw.githubusercontent.com/eclipse-emfcloud/emfcloud/master/codestyle/org.eclipse.emfcloud.checkstyle/src/main/resources/emfcloud-checkstyle-8.44.xml" type="remote" description="The central checkstyle configuration for EMF.cloud Checkstyle Version 8.44">
+    <additional-data name="cache-props-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.properties"/>
+    <additional-data name="cache-file-location" value="EMF.cloud Checkstyle (8.44)_1638214295838_cache.xml"/>
+    <additional-data name="cache-file" value="true"/>
+  </local-check-config>
+  <fileset name="all non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle (8.44)" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
+    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
   </fileset>
 </fileset-config>


### PR DESCRIPTION
The new release candiate uses a ruleset that is compliant with Checkstyle 8.44 as default.
This ensures that the checkstyle config can also be used in the latest Eclipse Relaease (8.44).
If you don't use the latest Eclipse release it's still recommended to update to the latest eclipse-checkstyle plugin version. However, the old checkstyle config (8.39) is still available and can be set in the project-specific properties.

Fixes #140