### PR TITLE
#47 Workspace configuration not working in Windows

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultUriHelper.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultUriHelper.java
@@ -67,7 +67,8 @@ public class DefaultUriHelper implements UriHelper {
    @Override
    public Optional<URI> toFileUri(final String fileUrl) {
       try {
-         File file = getAbsoluteFile(fileUrl);
+         String decodedUrl = URLDecoder.decode(fileUrl, "UTF-8");
+         File file = getAbsoluteFile(decodedUrl);
          URI uri = withTrailingSeparator(URI.createFileURI(file.toURI().normalize().getPath()));
          return Optional.ofNullable(uri).filter(URI::isFile);
       } catch (NullPointerException | IllegalArgumentException | UnsupportedEncodingException e) {

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/DefaultServerConfigurationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/configuration/DefaultServerConfigurationTest.java
@@ -40,6 +40,18 @@ public class DefaultServerConfigurationTest {
    public void normalizeWorkspaceRootEncoded() throws UnsupportedEncodingException {
       serverConfiguration.setWorkspaceRoot("file:/c%3A/foo%20bar/");
       assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), osEndsWith("c:/foo bar/"));
+
+      serverConfiguration.setWorkspaceRoot("/c%3A/foo%20bar2/");
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), osEndsWith("c:/foo bar2/"));
+   }
+
+   @Test
+   public void normalizeWorkspaceRootDecoded() throws UnsupportedEncodingException {
+      serverConfiguration.setWorkspaceRoot("file:/c:/foo bar/");
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), osEndsWith("c:/foo bar/"));
+
+      serverConfiguration.setWorkspaceRoot("c:/foo bar2/");
+      assertThat(serverConfiguration.getWorkspaceRootURI().toFileString(), osEndsWith("c:/foo bar2/"));
    }
 
    @Test


### PR DESCRIPTION
Updating the configuration via the `server/configure` endpoint does not work under Windows when used in combination with Modelserver Theia.
An absolute Windows path typically contains a driver letter followed by a : (e.g c://my-workspace). So when passing absolute paths as URL parameters the `:` need to be encoded.
This means we have to make sure that they are properly decoded on the server side.
The easiest common point to this this the `DefaultUriHelper` class.

Fixes #47