### PR TITLE
Undo/redo with JSON patches

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -386,7 +386,8 @@ public class DefaultModelResourceManager implements ModelResourceManager {
       if (!domain.undo()) {
          return Optional.empty();
       }
-      return clientCommand.map(cc -> new CommandExecutionContext(CommandExecutionType.UNDO, cc, serverCommand));
+      return Optional
+         .of(new CommandExecutionContext(CommandExecutionType.UNDO, clientCommand.orElse(null), serverCommand));
    }
 
    @Override
@@ -417,7 +418,8 @@ public class DefaultModelResourceManager implements ModelResourceManager {
       if (!domain.redo()) {
          return Optional.empty();
       }
-      return clientCommand.map(cc -> new CommandExecutionContext(CommandExecutionType.REDO, cc, serverCommand));
+      return Optional
+         .of(new CommandExecutionContext(CommandExecutionType.REDO, clientCommand.orElse(null), serverCommand));
    }
 
    protected CCommand encodeCommand(final Command command) {
@@ -484,7 +486,12 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    protected CCommandExecutionResult createExecutionResult(final CommandExecutionContext context) {
       CCommandExecutionResult result = CCommandFactory.eINSTANCE.createCommandExecutionResult();
       result.setType(context.getType());
-      result.setSource(EcoreUtil.copy(context.getClientCommand()));
+
+      // The client command will be null in the case of applying a JSON Patch
+      if (context.getClientCommand() != null) {
+         result.setSource(EcoreUtil.copy(context.getClientCommand()));
+      }
+
       Collection<?> affectedObjects = context.getServerCommand().getAffectedObjects();
       if (affectedObjects != null) {
          affectedObjects.stream()

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionController.java
@@ -196,7 +196,9 @@ public class DefaultSessionController implements SessionController {
    }
 
    protected void broadcastValidation(final String modeluri) {
-      broadcastValidation(modeluri, modelValidator.validate(modeluri));
+      if (hasOpenValidationSessions(modeluri)) {
+         broadcastValidation(modeluri, modelValidator.validate(modeluri));
+      }
    }
 
    protected void broadcastFullUpdate(final String modeluri, @Nullable final EObject updatedModel) {
@@ -241,7 +243,10 @@ public class DefaultSessionController implements SessionController {
    }
 
    protected void broadcastValidation(final String modeluri, final JsonNode newResult) {
-      getOpenValidationSessions(modeluri).forEach(session -> session.send(validationResult(newResult)));
+      if (hasOpenValidationSessions(modeluri)) {
+         final JsonNode validationResult = validationResult(newResult);
+         getOpenValidationSessions(modeluri).forEach(session -> session.send(validationResult));
+      }
    }
 
    /**
@@ -278,6 +283,10 @@ public class DefaultSessionController implements SessionController {
 
    protected Stream<WsContext> getOpenValidationSessions(final String modeluri) {
       return getAllOpenSessions(modeluri).filter(this::requiresLiveValidation);
+   }
+
+   protected boolean hasOpenValidationSessions(final String modeluri) {
+      return getAllOpenSessions(modeluri).anyMatch(this::requiresLiveValidation);
    }
 
    protected void broadcastError(final String modeluri, final String errorMessage) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultTransactionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultTransactionController.java
@@ -304,8 +304,9 @@ public class DefaultTransactionController implements TransactionController {
       public void apply(final WsMessageContext ctx, final ArrayNode patch) {
          try {
             // TODO: For now, we are letting the original patch stand in for its own result
-            modelRepository.executeCommand(modelURI, patch);
+            CCommandExecutionResult execution = modelRepository.executeCommand(modelURI, patch);
             JsonNode response = patch;
+            executions.add(execution);
             success(ctx, response);
          } catch (JsonPatchException | JsonPatchTestException exception) {
             error(ctx, "Inapplicable JSON patch", exception);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerEditingDomain.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerEditingDomain.java
@@ -129,7 +129,11 @@ public class ModelServerEditingDomain extends TransactionalEditingDomainImpl {
 
       // Don't unwrap the compound because execute must be a no-op, just placing it on the stack
       cCompound.map(compound -> new ModelServerCommand(command, compound))
-         .ifPresent(this::execute);
+         .ifPresentOrElse(this::execute,
+            () -> {
+               // We applied a JSON Patch, so there is no client command
+               execute(command);
+            });
    }
 
    /**


### PR DESCRIPTION
- undo stack was not getting an undoable command when all edits in a transaction were JSON patches
- add support for undo/redo (and execution results) of commands generated from JSON patches that do not have client commands
- do not perform live validation of the model if there are no listeners interested in it
