### PR TITLE
#150: Delta patch notifications on undo/redo

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.apache.log4j.Logger;
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -253,28 +255,26 @@ public class DefaultModelController implements ModelController {
 
    @Override
    public void undo(final Context ctx, final String modeluri) {
-      Optional<CCommandExecutionResult> undoExecution = modelRepository.undo(modeluri);
-      if (undoExecution.isPresent()) {
-         // TODO: Split v1 and v2 results
-         // In V2, send a jsonPatch response
-         success(ctx, "Successful undo.");
-         sessionController.commandExecuted(modeluri, undoExecution.get());
-         return;
-      }
-      accepted(ctx, "Cannot undo");
+      withModel(ctx, modeluri, root -> {
+         modelRepository.undo(modeluri).ifPresentOrElse(undoExecution -> {
+            success(ctx, "Successful undo.");
+
+            sessionController.commandExecuted(modeluri, Suppliers.ofInstance(undoExecution),
+               Suppliers.memoize(() -> getJSONPatchUpdate(ctx, modeluri, root, undoExecution)));
+         }, () -> accepted(ctx, "Cannot undo"));
+      });
    }
 
    @Override
    public void redo(final Context ctx, final String modeluri) {
-      Optional<CCommandExecutionResult> redoExecution = modelRepository.redo(modeluri);
-      if (redoExecution.isPresent()) {
-         // TODO: Split v1 and v2 results
-         // In V2, send a jsonPatch response
-         success(ctx, "Successful redo.");
-         sessionController.commandExecuted(modeluri, redoExecution.get());
-         return;
-      }
-      accepted(ctx, "Cannot redo");
+      withModel(ctx, modeluri, root -> {
+         modelRepository.redo(modeluri).ifPresentOrElse(redoExecution -> {
+            success(ctx, "Successful redo.");
+
+            sessionController.commandExecuted(modeluri, Suppliers.ofInstance(redoExecution),
+               Suppliers.memoize(() -> getJSONPatchUpdate(ctx, modeluri, root, redoExecution)));
+         }, () -> accepted(ctx, "Cannot redo"));
+      });
    }
 
    @Override
@@ -302,39 +302,35 @@ public class DefaultModelController implements ModelController {
 
    @Override
    public void executeCommand(final Context ctx, final String modelURI) {
-      Optional<EObject> root = this.modelRepository.getModel(modelURI);
-      if (root.isEmpty() || root.get() == null) {
-         modelNotFound(ctx, modelURI);
-         return;
-      }
-      Optional<CCommand> command = readPayload(ctx).filter(CCommand.class::isInstance).map(CCommand.class::cast);
-      if (command.isEmpty()) {
-         return;
-      }
-      try {
-         CCommandExecutionResult execution = modelRepository.executeCommand(modelURI, command.get());
-         sessionController.commandExecuted(modelURI, execution);
-         success(ctx, "Model '%s' successfully updated", modelURI);
-      } catch (DecodingException exception) {
-         decodingError(ctx, exception);
-      }
+      withModel(ctx, modelURI, root -> {
+         Optional<CCommand> command = readPayload(ctx).filter(CCommand.class::isInstance).map(CCommand.class::cast);
+         if (command.isEmpty()) {
+            return;
+         }
+         try {
+            CCommandExecutionResult execution = modelRepository.executeCommand(modelURI, command.get());
+
+            success(ctx, "Model '%s' successfully updated", modelURI);
+
+            sessionController.commandExecuted(modelURI, Suppliers.ofInstance(execution),
+               Suppliers.memoize(() -> getJSONPatchUpdate(ctx, modelURI, root, execution)));
+         } catch (DecodingException exception) {
+            decodingError(ctx, exception);
+         }
+      });
    }
 
    @Override
    public void executeCommandV2(final Context ctx, final String modelURI) {
-      Optional<EObject> root = this.modelRepository.getModel(modelURI);
-      if (root.isEmpty() || root.get() == null) {
-         modelNotFound(ctx, modelURI);
-         return;
-      }
-      Optional<PatchCommand<?>> command = readPatchCommand(ctx);
-      if (command.isPresent()) {
-         executePatchCommand(ctx, modelURI, root, command.get());
-      }
+      withModel(ctx, modelURI, root -> {
+         Optional<PatchCommand<?>> command = readPatchCommand(ctx);
+         command.ifPresent(pCommand -> executePatchCommand(ctx, modelURI, root, pCommand));
+      });
    }
 
-   protected void executePatchCommand(final Context ctx, final String modelURI, final Optional<EObject> root,
+   protected void executePatchCommand(final Context ctx, final String modelURI, final EObject root,
       final PatchCommand<?> pCommand) {
+
       CCommandExecutionResult result;
       if (isCCommand(pCommand)) {
          try {
@@ -356,12 +352,37 @@ public class DefaultModelController implements ModelController {
          return;
       }
 
-      try {
-         JsonNode patchResult = jsonPatchHelper.getJsonPatch(root.get(), result);
+      JsonNode patchResult = getJSONPatchUpdate(ctx, modelURI, root, result);
+      if (patchResult != null) {
          successPatch(ctx, patchResult, "Model '%s' successfully updated", modelURI);
-         sessionController.commandExecuted(modelURI, patchResult);
+
+         sessionController.commandExecuted(modelURI, Suppliers.ofInstance(result),
+            Suppliers.ofInstance(patchResult));
+      } else {
+         success(ctx, "Model '%s' successfully updated", modelURI);
+      }
+   }
+
+   /**
+    * Perform the given action on the indicated model, if present, or else return a 404 to the client.
+    *
+    * @param ctx         the client request context
+    * @param modelURI    the model on which to operation
+    * @param modelAction the operation to perform on the model
+    */
+   private void withModel(final Context ctx, final String modelURI, final Consumer<? super EObject> modelAction) {
+      Optional<EObject> root = this.modelRepository.getModel(modelURI);
+      root.ifPresentOrElse(modelAction, () -> modelNotFound(ctx, modelURI));
+   }
+
+   private JsonNode getJSONPatchUpdate(final Context ctx, final String modelURI, final EObject root,
+      final CCommandExecutionResult executionResult) {
+
+      try {
+         return jsonPatchHelper.getJsonPatch(root, executionResult);
       } catch (EncodingException ex) {
          LOG.error(ex.getMessage(), ex);
+         return null;
       }
    }
 

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelController.java
@@ -11,7 +11,7 @@
 package org.eclipse.emfcloud.modelserver.emf.common;
 
 import org.eclipse.emfcloud.modelserver.command.CCommand;
-import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV2;
+import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2;
 
 import io.javalin.http.Context;
 
@@ -55,8 +55,8 @@ public interface ModelController {
    /**
     * V2 version of the executeCommand API. This methods expects
     * a Json Object with a "type" attribute, where type may be
-    * either {@link ModelServerPathsV2#JSON_PATCH} or
-    * {@link ModelServerPathsV2#EMF_COMMAND}, and a "data" attribute
+    * either {@link ModelServerPathParametersV2#JSON_PATCH} or
+    * {@link ModelServerPathParametersV2#EMF_COMMAND}, and a "data" attribute
     * representing a Command or a Patch, in a format that corresponds
     * to the specified type.
     *

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelListener.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelListener.java
@@ -10,6 +10,8 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
+import java.util.function.Supplier;
+
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,10 +21,32 @@ public interface ModelListener {
 
    void modelUpdated(String modeluri);
 
+   /**
+    * @deprecated Use the {@link #commandExecuted(String, Supplier, Supplier)} API, instead, which
+    *             supports broadcast of model change notifications to v1 and v2 API subscribers
+    */
+   @Deprecated
    void commandExecuted(String modeluri, CCommandExecutionResult execution);
 
-   default void commandExecuted(final String modeluri, final JsonNode patch) {
-      // Does nothing by default
+   /**
+    * Notify of execution of a command or application of a JSON Patch.
+    * On execution of a command, the execution result will be provided but also a patch diff if
+    * the receiver wants it.
+    *
+    * @param modeluri  the model that was changed
+    * @param execution a supplier of the execution result describing the changes performed.
+    *                     Not itself {@code null} but it can supply a {@code null} if a JSON Patch was applied to the
+    *                     model
+    * @param patch     a supplier of the patch diff describing the changes performed.
+    *                     Not itself {@code null} but it can supply a {@code null} if for some reason it is unavailable
+    */
+   default void commandExecuted(final String modeluri, final Supplier<? extends CCommandExecutionResult> execution,
+      final Supplier<? extends JsonNode> patch) {
+
+      CCommandExecutionResult result = execution.get();
+      if (result != null) {
+         commandExecuted(modeluri, result);
+      }
    }
 
    void modelDeleted(String modeluri);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelper.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelper.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.util;
 
+import javax.inject.Inject;
+
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -41,6 +43,7 @@ public class JsonPatchHelper extends AbstractJsonPatchHelper {
    private final ModelResourceManager modelManager;
    private final ServerConfiguration serverConfiguration;
 
+   @Inject
    public JsonPatchHelper(final ModelResourceManager modelManager, final ServerConfiguration serverConfiguration) {
       this.modelManager = modelManager;
       this.serverConfiguration = serverConfiguration;

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/.gitignore
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/.gitignore
@@ -1,0 +1,1 @@
+TestReconcile.ecore

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -67,6 +68,7 @@ import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.patch.PatchCommandHandler;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -81,6 +83,7 @@ import org.mockito.stubbing.Answer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Suppliers;
 
 import io.javalin.http.Context;
 
@@ -236,7 +239,7 @@ public class DefaultModelControllerTest {
 
       // No subscribers registered for this incrementalUpdate, therefore no pre-encoded commands are created and the map
       // can remain empty for this test
-      verify(sessionController).commandExecuted(eq(modeluri), eq(result));
+      verify(sessionController).commandExecuted(eq(modeluri), eq(Suppliers.ofInstance(result)), anySupplier());
    }
 
    @Test
@@ -281,7 +284,7 @@ public class DefaultModelControllerTest {
       // No subscribers registered for this incrementalUpdate, therefore no pre-encoded commands are created and the map
       // can be remain for this test
 
-      verify(sessionController).commandExecuted(eq(modeluri), eq(result));
+      verify(sessionController).commandExecuted(eq(modeluri), eq(Suppliers.ofInstance(result)), anySupplier());
    }
 
    @Test
@@ -518,4 +521,9 @@ public class DefaultModelControllerTest {
          URI.createHierarchicalURI(new String[] { modeluri }, null, null)
             .resolve(serverConfiguration.getWorkspaceRootURI()));
    }
+
+   static <T> Supplier<T> anySupplier() {
+      return argThat(CoreMatchers.instanceOf(Supplier.class));
+   }
+
 }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
@@ -57,6 +57,7 @@ import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
+import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.XmiCodec;
@@ -67,10 +68,12 @@ import org.eclipse.emfcloud.modelserver.emf.common.codecs.DICodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.patch.PatchCommandHandler;
+import org.eclipse.emfcloud.modelserver.emf.util.JsonPatchHelper;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Before;
@@ -103,6 +106,8 @@ public class DefaultModelControllerTest {
    private SessionController sessionController;
    @Mock
    private ServerConfiguration serverConfiguration;
+   @Mock
+   private JsonPatchHelper jsonPatchHelper;
    @InjectMocks
    private DefaultModelValidator modelValidator;
 
@@ -125,7 +130,8 @@ public class DefaultModelControllerTest {
       modelValidator = new DefaultModelValidator(modelRepository, new DefaultFacetConfig(),
          EMFModule::setupDefaultMapper);
       modelController = new DefaultModelController(modelRepository, sessionController, serverConfiguration, codecs,
-         modelValidator, EMFModule::setupDefaultMapper, new PatchCommandHandler.RegistryImpl(), modelResourceManager);
+         modelValidator, EMFModule::setupDefaultMapper, new PatchCommandHandler.RegistryImpl(), modelResourceManager,
+         jsonPatchHelper);
    }
 
    @Test
@@ -285,6 +291,69 @@ public class DefaultModelControllerTest {
       // can be remain for this test
 
       verify(sessionController).commandExecuted(eq(modeluri), eq(Suppliers.ofInstance(result)), anySupplier());
+   }
+
+   @Test
+   public void undoRedo() throws EncodingException, DecodingException {
+      ResourceSet rset = new ResourceSetImpl();
+      String modeluri = "SuperBrewer3000.json";
+      JsonResource res = createJsonResource(modeluri);
+      rset.getResources().add(res);
+      final EClass eClass = EcoreFactory.eINSTANCE.createEClass();
+      res.getContents().add(eClass);
+
+      final EAttribute attribute = EcoreFactory.eINSTANCE.createEAttribute();
+      CCommand addCommand = CCommandFactory.eINSTANCE.createCommand();
+      addCommand.setType(EMFCommandType.ADD);
+      addCommand.setOwner(eClass);
+      addCommand.setFeature("eAttributes");
+      addCommand.getObjectsToAdd().add(attribute);
+      addCommand.getObjectValues().add(attribute);
+      JsonResource cmdRes = new JsonResource(URI.createURI("$command.json"));
+      cmdRes.getContents().add(addCommand);
+      String commandAsString = Json
+         .object(Json.prop(JsonResponseMember.DATA, Json.text(new JsonCodec().encode(addCommand).toString())))
+         .toString();
+
+      final LinkedHashMap<String, List<String>> queryParams = new LinkedHashMap<>();
+      queryParams.put(ModelServerPathParametersV2.MODEL_URI, Collections.singletonList(modeluri));
+      // This param is important to indicate that the result should include the JSON Patch
+      queryParams.put(ModelServerPathParametersV2.FORMAT, List.of(ModelServerPathParametersV2.FORMAT_JSON_V2));
+      when(context.queryParamMap()).thenReturn(queryParams);
+      when(context.body()).thenReturn(commandAsString);
+      when(context.matchedPath()).thenReturn("/api/v2/undo", "/api/v2/redo");
+      when(modelRepository.getModel(modeluri)).thenReturn(Optional.of(attribute));
+
+      CCommandExecutionResult result = CCommandFactory.eINSTANCE.createCommandExecutionResult();
+      result.setSource(EcoreUtil.copy(addCommand));
+      result.setType(CommandExecutionType.EXECUTE);
+
+      when(modelRepository.executeCommand(eq(modeluri), any(CCommand.class))).thenReturn(result);
+      when(modelRepository.undo(modeluri))
+         .thenReturn(Optional.of(CCommandFactory.eINSTANCE.createCommandExecutionResult()));
+      when(modelRepository.redo(modeluri))
+         .thenReturn(Optional.of(CCommandFactory.eINSTANCE.createCommandExecutionResult()));
+      when(jsonPatchHelper.getJsonPatch(any(), any())).thenReturn(
+         Json.array(Json.object(Map.of("op", Json.text("add")))),
+         Json.array(Json.object(Map.of("op", Json.text("remove")))),
+         Json.array(Json.object(Map.of("op", Json.text("add")))));
+
+      modelController.executeCommand(context, modeluri);
+
+      // unload to proxify
+      res.unload();
+
+      // No subscribers registered for this incrementalUpdate, therefore no pre-encoded commands are created and the map
+      // can be remain for this test
+
+      modelController.undo(context, modeluri);
+      modelController.redo(context, modeluri);
+
+      // Verify the execution
+      verify(context).json(argThat(jsonStringThat(CoreMatchers.containsString("successfully updated"))));
+      // And the undo/redo
+      verify(context, times(2))
+         .json(argThat(successWithDataThat(jsonStringThat(CoreMatchers.containsString("\"op\":")))));
    }
 
    @Test
@@ -524,6 +593,29 @@ public class DefaultModelControllerTest {
 
    static <T> Supplier<T> anySupplier() {
       return argThat(CoreMatchers.instanceOf(Supplier.class));
+   }
+
+   static Matcher<JsonNode> successWithDataThat(final Matcher<? super JsonNode> jsonMatcher) {
+      return CoreMatchers.both(jsonStringThat(CoreMatchers.containsString("success")))
+         .and(dataThat(jsonMatcher));
+   }
+
+   static Matcher<JsonNode> dataThat(final Matcher<? super JsonNode> jsonMatcher) {
+      return new FeatureMatcher<JsonNode, JsonNode>(jsonMatcher, "data payload", "data") {
+         @Override
+         protected JsonNode featureValueOf(final JsonNode actual) {
+            return actual.get("data");
+         }
+      };
+   }
+
+   static Matcher<JsonNode> jsonStringThat(final Matcher<? super String> stringMatcher) {
+      return new FeatureMatcher<JsonNode, String>(stringMatcher, "string representation", "toString") {
+         @Override
+         protected String featureValueOf(final JsonNode actual) {
+            return actual.toString();
+         }
+      };
    }
 
 }


### PR DESCRIPTION
- ensure that v2 subscribers get JSON Patch delta notifications on undo/redo
- unify v1 and v2 incremental change notification so that both v1 and v2 subscribers get deltas of their flavour from command or patch execute/undo/redo (in the case of JSON Patches v1 subscribers don't get a source command)
- defer calculation of JSON Patch delta so that it won't be computed if it is not needed
