### PR TITLE
API v2: Prefer delegation over inheritance

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -20,7 +20,7 @@ import okhttp3.OkHttpClient;
 
 public class ModelServerClient extends ModelServerClientV2 {
 
-   public static final Set<String> DEFAULT_SUPPORTED_FORMATS = ModelServerClientV2.DEFAULT_SUPPORTED_FORMATS;
+   public static final Set<String> DEFAULT_SUPPORTED_FORMATS = ModelServerClientV2.SUPPORTED_FORMATS;
    public static final String PATCH = ModelServerClientV2.PATCH;
    public static final String POST = ModelServerClientV2.POST;
 

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v1/ModelServerClientV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v1/ModelServerClientV1.java
@@ -11,88 +11,285 @@
 package org.eclipse.emfcloud.modelserver.client.v1;
 
 import java.net.MalformedURLException;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emfcloud.modelserver.client.AbstractModelServerClient;
 import org.eclipse.emfcloud.modelserver.client.EditingContext;
+import org.eclipse.emfcloud.modelserver.client.Model;
 import org.eclipse.emfcloud.modelserver.client.ModelServerClientApiV1;
 import org.eclipse.emfcloud.modelserver.client.Response;
+import org.eclipse.emfcloud.modelserver.client.ServerConfiguration;
+import org.eclipse.emfcloud.modelserver.client.SubscriptionListener;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV1;
 import org.eclipse.emfcloud.modelserver.emf.common.JsonResponseMember;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
-import org.eclipse.emfcloud.modelserver.internal.client.EditingContextImpl;
+import org.eclipse.emfcloud.modelserver.internal.client.ModelServerClientDelegate;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.WebSocket;
 
-public class ModelServerClientV1 extends AbstractModelServerClient
-   implements ModelServerClientApiV1<EObject>, ModelServerPathsV1 {
+public class ModelServerClientV1 implements ModelServerClientApiV1<EObject>, ModelServerPathsV1, AutoCloseable {
 
-   public static final Set<String> DEFAULT_SUPPORTED_FORMATS = AbstractModelServerClient.DEFAULT_SUPPORTED_FORMATS;
+   public static final Set<String> SUPPORTED_FORMATS = Set.of(ModelServerPathParametersV1.FORMAT_JSON,
+      ModelServerPathParametersV1.FORMAT_XMI);
 
    protected static final Logger LOG = LogManager.getLogger(ModelServerClientV1.class);
+
+   private final ModelServerClientDelegate delegate;
 
    public ModelServerClientV1(final String baseUrl, final EPackageConfiguration... configurations)
       throws MalformedURLException {
 
-      super(baseUrl, ModelServerPathParametersV1.FORMAT_JSON, configurations);
+      this(new ModelServerClientDelegate(baseUrl, ModelServerPathParametersV1.FORMAT_JSON, SUPPORTED_FORMATS,
+         configurations));
    }
 
    public ModelServerClientV1(final OkHttpClient client, final String baseUrl,
       final EPackageConfiguration... configurations) throws MalformedURLException {
 
-      super(client, baseUrl, ModelServerPathParametersV1.FORMAT_JSON, configurations);
+      this(new ModelServerClientDelegate(client, baseUrl, ModelServerPathParametersV1.FORMAT_JSON, SUPPORTED_FORMATS,
+         configurations));
+   }
+
+   protected ModelServerClientV1(final ModelServerClientDelegate delegate) {
+      super();
+
+      this.delegate = delegate;
+   }
+
+   @Override
+   public void close() {
+      delegate.close();
    }
 
    @Override
    public CompletableFuture<Response<Boolean>> edit(final String modelUri, final CCommand command,
       final String format) {
-      String checkedFormat = checkedFormat(format);
+      String checkedFormat = delegate.checkedFormat(format);
       final Request request = new Request.Builder()
          .url(
-            createHttpUrlBuilder(makeUrl(EDIT))
+            delegate.createHttpUrlBuilder(delegate.makeUrl(EDIT))
                .addQueryParameter(ModelServerPathParametersV1.MODEL_URI, modelUri)
                .addQueryParameter(ModelServerPathParametersV1.FORMAT, checkedFormat)
                .build())
          .patch(
             RequestBody.create(
                Json.object(
-                  Json.prop(JsonResponseMember.DATA, Json.text(encode(command, checkedFormat)))).toString(),
+                  Json.prop(JsonResponseMember.DATA, Json.text(delegate.encode(command, checkedFormat)))).toString(),
                MediaType.parse("application/json")))
          .build();
 
-      return makeCallAndExpectSuccess(request);
+      return delegate.makeCallAndExpectSuccess(request);
    }
 
    @Override
    public EditingContext edit() {
-      EditingContextImpl<?> result;
+      return delegate.edit(delegate, EDIT, ModelServerClientDelegate::encode);
+   }
 
-      if (!openEditingSockets.isEmpty()) {
-         result = openEditingSockets.keySet().iterator().next();
-         result.retain();
-         return result;
-      }
+   //
+   // Delegation methods
+   //
 
-      Request request = new Request.Builder()
-         .url(makeWsUrl(EDIT))
-         .build();
-      result = new EditingContextImpl<>(this, ModelServerClientV1::encode);
+   @Override
+   public CompletableFuture<Response<String>> get(final String modelUri) {
+      return delegate.get(modelUri);
+   }
 
-      final WebSocket socket = client.newWebSocket(request, result);
-      openEditingSockets.put(result, socket);
+   @Override
+   public CompletableFuture<Response<EObject>> get(final String modelUri, final String format) {
+      return delegate.get(modelUri, format);
+   }
 
-      return result;
+   @Override
+   public CompletableFuture<Response<List<Model<String>>>> getAll() { return delegate.getAll(); }
+
+   @Override
+   public CompletableFuture<Response<List<Model<EObject>>>> getAll(final String format) {
+      return delegate.getAll(format);
+   }
+
+   @Override
+   public CompletableFuture<Response<List<String>>> getModelUris() { return delegate.getModelUris(); }
+
+   @Override
+   public CompletableFuture<Response<String>> getModelElementById(final String modelUri, final String elementid) {
+      return delegate.getModelElementById(modelUri, elementid);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> getModelElementById(final String modelUri, final String elementid,
+      final String format) {
+
+      return delegate.getModelElementById(modelUri, elementid, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getModelElementByName(final String modelUri, final String elementname) {
+      return delegate.getModelElementByName(modelUri, elementname);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> getModelElementByName(final String modelUri, final String elementname,
+      final String format) {
+
+      return delegate.getModelElementByName(modelUri, elementname, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> delete(final String modelUri) {
+      return delegate.delete(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> close(final String modelUri) {
+      return delegate.close(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> create(final String modelUri, final String createdModelAsJsonText) {
+      return delegate.create(modelUri, createdModelAsJsonText);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> create(final String modelUri, final EObject createdModel,
+      final String format) {
+
+      return delegate.create(modelUri, createdModel, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> update(final String modelUri, final String updatedModelAsJsonText) {
+      return delegate.update(modelUri, updatedModelAsJsonText);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> update(final String modelUri, final EObject updatedModel,
+      final String format) {
+
+      return delegate.update(modelUri, updatedModel, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> save(final String modelUri) {
+      return delegate.save(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> saveAll() {
+      return delegate.saveAll();
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> validate(final String modelUri) {
+      return delegate.validate(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getValidationConstraints(final String modelUri) {
+      return delegate.getValidationConstraints(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getTypeSchema(final String modelUri) {
+      return delegate.getTypeSchema(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getUiSchema(final String schemaName) {
+      return delegate.getUiSchema(schemaName);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> configure(final ServerConfiguration configuration) {
+      return delegate.configure(configuration);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> ping() {
+      return delegate.ping();
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener) {
+      delegate.subscribe(modelUri, subscriptionListener);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener, final String format) {
+      delegate.subscribe(modelUri, subscriptionListener, format);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener, final long timeout) {
+      delegate.subscribe(modelUri, subscriptionListener, timeout);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener, final String format,
+      final long timeout) {
+
+      delegate.subscribe(modelUri, subscriptionListener, format, timeout);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener) {
+      delegate.subscribeWithValidation(modelUri, subscriptionListener);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener,
+      final String format) {
+
+      delegate.subscribeWithValidation(modelUri, subscriptionListener, format);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener,
+      final long timeout) {
+
+      delegate.subscribeWithValidation(modelUri, subscriptionListener, timeout);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener,
+      final String format, final long timeout) {
+
+      delegate.subscribeWithValidation(modelUri, subscriptionListener, format, timeout);
+   }
+
+   @Override
+   public boolean send(final String modelUri, final String message) {
+      return delegate.send(modelUri, message);
+   }
+
+   @Override
+   public boolean unsubscribe(final String modelUri) {
+      return delegate.unsubscribe(modelUri);
+   }
+
+   @Override
+   public boolean close(final EditingContext editingContext) {
+      return delegate.close(editingContext);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> undo(final String modelUri) {
+      return delegate.undo(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> redo(final String modelUri) {
+      return delegate.redo(modelUri);
    }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v2/ModelServerClientV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v2/ModelServerClientV2.java
@@ -11,6 +11,7 @@
 package org.eclipse.emfcloud.modelserver.client.v2;
 
 import java.net.MalformedURLException;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -18,79 +19,85 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emfcloud.modelserver.client.AbstractModelServerClient;
 import org.eclipse.emfcloud.modelserver.client.EditingContext;
+import org.eclipse.emfcloud.modelserver.client.Model;
 import org.eclipse.emfcloud.modelserver.client.ModelServerClientApi;
 import org.eclipse.emfcloud.modelserver.client.Response;
+import org.eclipse.emfcloud.modelserver.client.ServerConfiguration;
+import org.eclipse.emfcloud.modelserver.client.SubscriptionListener;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPaths;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
-import org.eclipse.emfcloud.modelserver.emf.common.JsonResponseMember;
+import org.eclipse.emfcloud.modelserver.emf.common.JsonRequestMember;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodecV2;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
-import org.eclipse.emfcloud.modelserver.internal.client.EditingContextImpl;
+import org.eclipse.emfcloud.modelserver.internal.client.ModelServerClientDelegate;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.collect.ImmutableSet;
 
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.WebSocket;
 
-public class ModelServerClientV2 extends AbstractModelServerClient
-   implements ModelServerClientApi<EObject>, ModelServerPaths {
+public class ModelServerClientV2 implements ModelServerClientApi<EObject>, ModelServerPaths, AutoCloseable {
 
-   public static final Set<String> DEFAULT_SUPPORTED_FORMATS = ImmutableSet.<String> builder()
-      .addAll(AbstractModelServerClient.DEFAULT_SUPPORTED_FORMATS)
-      .add(ModelServerPathParametersV2.FORMAT_JSON_V2)
-      .build();
+   public static final Set<String> SUPPORTED_FORMATS = Set.of(ModelServerPathParametersV2.FORMAT_JSON,
+      ModelServerPathParametersV2.FORMAT_XMI, ModelServerPathParametersV2.FORMAT_JSON_V2);
 
    public static final String PATCH = "PATCH";
    public static final String POST = "POST";
 
    protected static final Logger LOG = LogManager.getLogger(ModelServerClientV2.class);
 
+   private final ModelServerClientDelegate delegate;
+
    public ModelServerClientV2(final String baseUrl, final EPackageConfiguration... configurations)
       throws MalformedURLException {
-      super(baseUrl, ModelServerPathParametersV2.FORMAT_JSON_V2, configurations);
+
+      this(new ModelServerClientDelegate(baseUrl, ModelServerPathParametersV2.FORMAT_JSON_V2, SUPPORTED_FORMATS,
+         configurations));
    }
 
    public ModelServerClientV2(final OkHttpClient client, final String baseUrl,
       final EPackageConfiguration... configurations) throws MalformedURLException {
 
-      super(client, baseUrl, ModelServerPathParametersV2.FORMAT_JSON_V2, configurations);
+      this(new ModelServerClientDelegate(client, baseUrl, ModelServerPathParametersV2.FORMAT_JSON_V2,
+         SUPPORTED_FORMATS, configurations));
+   }
+
+   protected ModelServerClientV2(final ModelServerClientDelegate delegate) {
+      super();
+
+      this.delegate = delegate;
    }
 
    @Override
-   protected boolean isSupportedFormat(final String format) {
-      return DEFAULT_SUPPORTED_FORMATS.contains(format);
+   public void close() {
+      delegate.close();
    }
 
-   @Override
    public String encode(final EObject eObject, final String format) {
       try {
          if (format.equals(ModelServerPathParametersV2.FORMAT_JSON_V2)) {
             return new JsonCodecV2().encode(eObject).toString();
          }
-         return super.encode(eObject, format);
+         return delegate.encode(eObject, format);
       } catch (EncodingException e) {
          LOG.error("Encoding of " + eObject + " with " + format + " format failed");
          throw new RuntimeException(e);
       }
    }
 
-   @Override
    public Optional<EObject> decode(final String payload, final String format) {
       try {
          if (format.equals(ModelServerPathParametersV2.FORMAT_JSON_V2)) {
             return new JsonCodecV2().decode(payload);
          }
-         return super.decode(payload, format);
+         return delegate.decode(payload, format);
       } catch (DecodingException e) {
          LOG.error("Decoding of " + payload + " with " + format + " format failed");
       }
@@ -100,62 +107,52 @@ public class ModelServerClientV2 extends AbstractModelServerClient
    @Override
    public CompletableFuture<Response<Boolean>> edit(final String modelUri, final CCommand command,
       final String format) {
-      String checkedFormat = checkedFormat(format);
+      String checkedFormat = delegate.checkedFormat(format);
       final Request request = new Request.Builder()
          .url(
-            createHttpUrlBuilder(makeUrl(MODEL_BASE_PATH))
+            delegate.createHttpUrlBuilder(delegate.makeUrl(MODEL_BASE_PATH))
                .addQueryParameter(ModelServerPathParametersV2.MODEL_URI, modelUri)
                .addQueryParameter(ModelServerPathParametersV2.FORMAT, checkedFormat)
                .build())
          .patch(
             RequestBody.create(
                Json.object(
-                  Json.prop(JsonResponseMember.DATA, Json.text(encode(command, checkedFormat)))).toString(),
+                  Json.prop(JsonRequestMember.DATA, Json.object(
+                     Json.prop(JsonRequestMember.TYPE, Json.text(ModelServerPathParametersV2.EMF_COMMAND)),
+                     Json.prop(JsonRequestMember.DATA, Json.text(encode(command, checkedFormat))))))
+                  .toString(),
                MediaType.parse("application/json")))
          .build();
 
-      return makeCallAndExpectSuccess(request);
+      return delegate.makeCallAndExpectSuccess(request);
    }
 
    @Override
    public CompletableFuture<Response<Boolean>> edit(final String modelUri, final ArrayNode jsonPatch,
       final String format) {
-      String checkedFormat = checkedFormat(format);
+      String checkedFormat = delegate.checkedFormat(format);
       final Request request = new Request.Builder()
          .url(
-            createHttpUrlBuilder(makeUrl(MODEL_BASE_PATH))
+            delegate.createHttpUrlBuilder(delegate.makeUrl(MODEL_BASE_PATH))
                .addQueryParameter(ModelServerPathParametersV2.MODEL_URI, modelUri)
                .addQueryParameter(ModelServerPathParametersV2.FORMAT, checkedFormat)
                .build())
          .patch(
             RequestBody.create(
                Json.object(
-                  Json.prop(JsonResponseMember.DATA, Json.text(encode(jsonPatch)))).toString(),
+                  Json.prop(JsonRequestMember.DATA, Json.object(
+                     Json.prop(JsonRequestMember.TYPE, Json.text(ModelServerPathParametersV2.JSON_PATCH)),
+                     Json.prop(JsonRequestMember.DATA, Json.text(encode(jsonPatch))))))
+                  .toString(),
                MediaType.parse("application/json")))
          .build();
 
-      return makeCallAndExpectSuccess(request);
+      return delegate.makeCallAndExpectSuccess(request);
    }
 
    @Override
    public EditingContext edit() {
-      EditingContextImpl<?> result;
-
-      if (!openEditingSockets.isEmpty()) {
-         result = openEditingSockets.keySet().iterator().next();
-         result.retain();
-         return result;
-      }
-
-      Request request = new Request.Builder()
-         .url(makeWsUrl(MODEL_BASE_PATH))
-         .build();
-      result = new EditingContextImpl<>(this, ModelServerClientV2::encode);
-
-      final WebSocket socket = client.newWebSocket(request, result);
-      openEditingSockets.put(result, socket);
-
-      return result;
+      return delegate.edit(this, MODEL_BASE_PATH, ModelServerClientV2::encode);
    }
 
    /**
@@ -168,6 +165,202 @@ public class ModelServerClientV2 extends AbstractModelServerClient
     */
    public String encode(final ArrayNode node) {
       return node.toString();
+   }
+
+   //
+   // Delegation methods
+   //
+
+   @Override
+   public CompletableFuture<Response<String>> get(final String modelUri) {
+      return delegate.get(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> get(final String modelUri, final String format) {
+      return delegate.get(modelUri, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<List<Model<String>>>> getAll() { return delegate.getAll(); }
+
+   @Override
+   public CompletableFuture<Response<List<Model<EObject>>>> getAll(final String format) {
+      return delegate.getAll(format);
+   }
+
+   @Override
+   public CompletableFuture<Response<List<String>>> getModelUris() { return delegate.getModelUris(); }
+
+   @Override
+   public CompletableFuture<Response<String>> getModelElementById(final String modelUri, final String elementid) {
+      return delegate.getModelElementById(modelUri, elementid);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> getModelElementById(final String modelUri, final String elementid,
+      final String format) {
+
+      return delegate.getModelElementById(modelUri, elementid, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getModelElementByName(final String modelUri, final String elementname) {
+      return delegate.getModelElementByName(modelUri, elementname);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> getModelElementByName(final String modelUri, final String elementname,
+      final String format) {
+
+      return delegate.getModelElementByName(modelUri, elementname, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> delete(final String modelUri) {
+      return delegate.delete(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> close(final String modelUri) {
+      return delegate.close(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> create(final String modelUri, final String createdModelAsJsonText) {
+      return delegate.create(modelUri, createdModelAsJsonText);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> create(final String modelUri, final EObject createdModel,
+      final String format) {
+
+      return delegate.create(modelUri, createdModel, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> update(final String modelUri, final String updatedModelAsJsonText) {
+      return delegate.update(modelUri, updatedModelAsJsonText);
+   }
+
+   @Override
+   public CompletableFuture<Response<EObject>> update(final String modelUri, final EObject updatedModel,
+      final String format) {
+
+      return delegate.update(modelUri, updatedModel, format);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> save(final String modelUri) {
+      return delegate.save(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> saveAll() {
+      return delegate.saveAll();
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> validate(final String modelUri) {
+      return delegate.validate(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getValidationConstraints(final String modelUri) {
+      return delegate.getValidationConstraints(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getTypeSchema(final String modelUri) {
+      return delegate.getTypeSchema(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<String>> getUiSchema(final String schemaName) {
+      return delegate.getUiSchema(schemaName);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> configure(final ServerConfiguration configuration) {
+      return delegate.configure(configuration);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> ping() {
+      return delegate.ping();
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener) {
+      delegate.subscribe(modelUri, subscriptionListener);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener, final String format) {
+      delegate.subscribe(modelUri, subscriptionListener, format);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener, final long timeout) {
+      delegate.subscribe(modelUri, subscriptionListener, timeout);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener, final String format,
+      final long timeout) {
+
+      delegate.subscribe(modelUri, subscriptionListener, format, timeout);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener) {
+      delegate.subscribeWithValidation(modelUri, subscriptionListener);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener,
+      final String format) {
+
+      delegate.subscribeWithValidation(modelUri, subscriptionListener, format);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener,
+      final long timeout) {
+
+      delegate.subscribeWithValidation(modelUri, subscriptionListener, timeout);
+   }
+
+   @Override
+   public void subscribeWithValidation(final String modelUri, final SubscriptionListener subscriptionListener,
+      final String format, final long timeout) {
+
+      delegate.subscribeWithValidation(modelUri, subscriptionListener, format, timeout);
+   }
+
+   @Override
+   public boolean send(final String modelUri, final String message) {
+      return delegate.send(modelUri, message);
+   }
+
+   @Override
+   public boolean unsubscribe(final String modelUri) {
+      return delegate.unsubscribe(modelUri);
+   }
+
+   @Override
+   public boolean close(final EditingContext editingContext) {
+      return delegate.close(editingContext);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> undo(final String modelUri) {
+      return delegate.undo(modelUri);
+   }
+
+   @Override
+   public CompletableFuture<Response<Boolean>> redo(final String modelUri) {
+      return delegate.redo(modelUri);
    }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
@@ -10,35 +10,79 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
+import static io.javalin.apibuilder.ApiBuilder.after;
+import static io.javalin.apibuilder.ApiBuilder.before;
+import static io.javalin.apibuilder.ApiBuilder.delete;
+import static io.javalin.apibuilder.ApiBuilder.get;
 import static io.javalin.apibuilder.ApiBuilder.patch;
+import static io.javalin.apibuilder.ApiBuilder.post;
+import static io.javalin.apibuilder.ApiBuilder.put;
+import static io.javalin.apibuilder.ApiBuilder.ws;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV1;
+import org.eclipse.emfcloud.modelserver.common.Routing;
 
 import com.google.inject.Inject;
 
 import io.javalin.Javalin;
 
-public class ModelServerRoutingV1 extends AbstractModelServerRouting {
-   protected static final Logger LOG = LogManager.getLogger(ModelServerRoutingV1.class);
+public class ModelServerRoutingV1 implements Routing {
+
+   protected final ModelServerRoutingDelegate delegate;
 
    @Inject
    public ModelServerRoutingV1(final Javalin javalin, final ModelResourceManager resourceManager,
       final ModelController modelController, final SchemaController schemaController,
       final ServerController serverController, final SessionController sessionController) {
 
-      super(javalin, resourceManager, modelController, schemaController, serverController, sessionController);
+      super();
+
+      this.delegate = new ModelServerRoutingDelegate(javalin, resourceManager, modelController, schemaController,
+         serverController, sessionController, ModelServerPathsV1.BASE_PATH);
    }
 
    @Override
-   protected void apiEndpoints() {
-      super.apiEndpoints();
-
-      patch(ModelServerPathsV1.MODEL_BASE_PATH, this::setModel);
-      patch(ModelServerPathsV1.EDIT, this::executeCommand);
+   public void bindRoutes() {
+      delegate.bindRoutes(this::endpoints);
    }
 
-   @Override
-   protected String getBasePath() { return ModelServerPathsV1.BASE_PATH; }
+   private void endpoints() {
+      before(delegate::waitForPrecondition);
+
+      get(ModelServerPathsV1.MODEL_BASE_PATH, delegate::getModel);
+      post(ModelServerPathsV1.MODEL_BASE_PATH, delegate::createModel);
+      delete(ModelServerPathsV1.MODEL_BASE_PATH, delegate::deleteModel);
+
+      post(ModelServerPathsV1.CLOSE, delegate::closeModel);
+
+      get(ModelServerPathsV1.UNDO, delegate::undoCommand);
+      get(ModelServerPathsV1.REDO, delegate::redoCommand);
+
+      get(ModelServerPathsV1.MODEL_ELEMENT, delegate::getModelElement);
+
+      get(ModelServerPathsV1.SAVE, delegate::saveModel);
+      get(ModelServerPathsV1.SAVE_ALL, delegate::saveAllModels);
+
+      get(ModelServerPathsV1.MODEL_URIS, delegate::getModelUris);
+
+      get(ModelServerPathsV1.TYPE_SCHEMA, delegate::getTypeSchema);
+
+      get(ModelServerPathsV1.UI_SCHEMA, delegate::getUiSchema);
+
+      before(ModelServerPathsV1.SERVER_CONFIGURE, delegate::beforeServerConfigure);
+      put(ModelServerPathsV1.SERVER_CONFIGURE, delegate::serverConfigure);
+      after(ModelServerPathsV1.SERVER_CONFIGURE, delegate::afterServerConfigure);
+
+      get(ModelServerPathsV1.SERVER_PING, delegate::serverPing);
+
+      get(ModelServerPathsV1.VALIDATION, delegate::validateModel);
+      get(ModelServerPathsV1.VALIDATION_CONSTRAINTS, delegate::getValidationConstraints);
+
+      patch(ModelServerPathsV1.MODEL_BASE_PATH, delegate::setModel);
+      patch(ModelServerPathsV1.EDIT, delegate::executeCommand);
+
+      ws(ModelServerPathsV1.SUBSCRIPTION, delegate::subscribe);
+
+      // TODO: ws for the commands
+   }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV2.java
@@ -10,6 +10,10 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
+import static io.javalin.apibuilder.ApiBuilder.after;
+import static io.javalin.apibuilder.ApiBuilder.before;
+import static io.javalin.apibuilder.ApiBuilder.delete;
+import static io.javalin.apibuilder.ApiBuilder.get;
 import static io.javalin.apibuilder.ApiBuilder.patch;
 import static io.javalin.apibuilder.ApiBuilder.post;
 import static io.javalin.apibuilder.ApiBuilder.put;
@@ -18,11 +22,8 @@ import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV
 import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextResponse.error;
 import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextResponse.missingParameter;
 
-import java.util.Optional;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV2;
+import org.eclipse.emfcloud.modelserver.common.Routing;
 
 import com.google.inject.Inject;
 
@@ -31,15 +32,17 @@ import io.javalin.http.Context;
 import io.javalin.websocket.WsConfig;
 import io.javalin.websocket.WsConnectContext;
 
-public class ModelServerRoutingV2 extends AbstractModelServerRouting {
+public class ModelServerRoutingV2 implements Routing {
    /**
     * This is not declared in the {@link ModelServerPathsV2} namespace because it is an
     * internal endpoint intended for use only by other model server instances.
     */
    protected static final String TRANSACTION_ENDPOINT = "transaction";
 
-   protected static final Logger LOG = LogManager.getLogger(ModelServerRoutingV2.class);
+   protected final ModelServerRoutingDelegate delegate;
 
+   protected final ModelController modelController;
+   protected final SessionController sessionController;
    protected final TransactionController transactionController;
 
    @Inject
@@ -48,19 +51,57 @@ public class ModelServerRoutingV2 extends AbstractModelServerRouting {
       final ServerController serverController, final SessionController sessionController,
       final TransactionController transactionController) {
 
-      super(javalin, resourceManager, modelController, schemaController, serverController, sessionController);
+      super();
 
+      this.delegate = new ModelServerRoutingDelegate(javalin, resourceManager, modelController, schemaController,
+         serverController, sessionController, ModelServerPathsV2.BASE_PATH);
+      delegate.setSubscriptionConnectionHandler(this::connectSubscription);
+
+      this.modelController = modelController;
+      this.sessionController = sessionController;
       this.transactionController = transactionController;
    }
 
    @Override
-   protected String getBasePath() { return ModelServerPathsV2.BASE_PATH; }
+   public void bindRoutes() {
+      delegate.bindRoutes(this::endpoints);
+   }
 
-   @Override
-   protected void apiEndpoints() {
-      super.apiEndpoints();
+   private void endpoints() {
+      before(delegate::waitForPrecondition);
 
-      put(ModelServerPathsV2.MODEL_BASE_PATH, this::setModel); // Was PATCH in V1
+      get(ModelServerPathsV2.MODEL_BASE_PATH, delegate::getModel);
+      post(ModelServerPathsV2.MODEL_BASE_PATH, delegate::createModel);
+      delete(ModelServerPathsV2.MODEL_BASE_PATH, delegate::deleteModel);
+
+      post(ModelServerPathsV2.CLOSE, delegate::closeModel);
+
+      get(ModelServerPathsV2.UNDO, delegate::undoCommand);
+      get(ModelServerPathsV2.REDO, delegate::redoCommand);
+
+      get(ModelServerPathsV2.MODEL_ELEMENT, delegate::getModelElement);
+
+      get(ModelServerPathsV2.SAVE, delegate::saveModel);
+      get(ModelServerPathsV2.SAVE_ALL, delegate::saveAllModels);
+
+      get(ModelServerPathsV2.MODEL_URIS, delegate::getModelUris);
+
+      get(ModelServerPathsV2.TYPE_SCHEMA, delegate::getTypeSchema);
+
+      get(ModelServerPathsV2.UI_SCHEMA, delegate::getUiSchema);
+
+      before(ModelServerPathsV2.SERVER_CONFIGURE, delegate::beforeServerConfigure);
+      put(ModelServerPathsV2.SERVER_CONFIGURE, delegate::serverConfigure);
+      after(ModelServerPathsV2.SERVER_CONFIGURE, delegate::afterServerConfigure);
+
+      get(ModelServerPathsV2.SERVER_PING, delegate::serverPing);
+
+      get(ModelServerPathsV2.VALIDATION, delegate::validateModel);
+      get(ModelServerPathsV2.VALIDATION_CONSTRAINTS, delegate::getValidationConstraints);
+
+      ws(ModelServerPathsV2.SUBSCRIPTION, delegate::subscribe);
+
+      put(ModelServerPathsV2.MODEL_BASE_PATH, delegate::setModel); // Was PATCH in V1
 
       patch(ModelServerPathsV2.MODEL_BASE_PATH, this::executeCommand); // Was PATCH /edit in V1
 
@@ -68,23 +109,15 @@ public class ModelServerRoutingV2 extends AbstractModelServerRouting {
       ws(TRANSACTION_ENDPOINT + "/{id}", this::openTransaction);
    }
 
-   @Override
-   protected void onSubscriptionConnect(final WsConnectContext ctx) {
-      Optional<String> modelUri = getResolvedFileUri(ctx.queryParamMap(), MODEL_URI);
-      if (modelUri.isEmpty()) {
-         missingParameter(ctx, MODEL_URI);
-         ctx.session.close();
-         return;
-      }
-
-      if (!sessionController.subscribeV2(ctx, modelUri.get())) {
-         error(ctx, "Cannot subscribe to '%s': modeluri is not a valid model resource", modelUri.get());
+   protected void connectSubscription(final WsConnectContext ctx, final String modelUri) {
+      if (!sessionController.subscribeV2(ctx, modelUri)) {
+         error(ctx, "Cannot subscribe to '%s': modeluri is not a valid model resource", modelUri);
          ctx.session.close();
       }
    }
 
    protected void createTransaction(final Context ctx) {
-      getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
+      delegate.getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
          param -> transactionController.create(ctx, param),
          () -> missingParameter(ctx, MODEL_URI));
    }
@@ -96,9 +129,8 @@ public class ModelServerRoutingV2 extends AbstractModelServerRouting {
       wsConfig.onMessage(transactionController::onMessage);
    }
 
-   @Override
    protected void executeCommand(final Context ctx) {
-      getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
+      delegate.getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
          param -> modelController.executeCommandV2(ctx, param),
          () -> missingParameter(ctx, MODEL_URI));
    }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/JsonCodecV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/JsonCodecV2.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV2;
 import org.eclipse.emfcloud.modelserver.common.codecs.DefaultJsonCodec;
 import org.eclipse.emfcloud.modelserver.common.codecs.EMFJsonConverter;
@@ -55,13 +56,20 @@ public class JsonCodecV2 extends DefaultJsonCodec {
 
    @Override
    public JsonNode encode(final EObject obj) throws EncodingException {
-      // FIXME: The super implementation creates a JsonResource, which doesn't (seem to) support
+      // The super implementation creates a JsonResource, which doesn't (seem to) support
       // IDs at all. When used with the $id: feature, it results in $id:null for all elements.
-      // Directly serialize the object, without moving it to a separate resource.
+
+      Resource original = obj.eResource();
+      if (original == null) {
+         // If it's not in a resource, then the superclass implementation will do just as well
+         // because nothing can have an ID, anyways
+         return super.encode(obj);
+      }
+
+      // FIXME: Directly serialize the object, without moving it to a separate resource.
       // However, by doing this, we might break href-references in some cases? TO BE INVESTIGATED
       // Alternatively, we could use a custom ID-Provider (Or delegate to the original resource for IDs?)
-      // return super.encode(obj);
-      return super.encode(obj, getObjectMapper());
+      return DefaultJsonCodec.encode(obj, getObjectMapper());
    }
 
 }

--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
@@ -23,9 +23,9 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emfcloud.modelserver.client.Model;
+import org.eclipse.emfcloud.modelserver.client.ModelServerClient;
 import org.eclipse.emfcloud.modelserver.client.Response;
 import org.eclipse.emfcloud.modelserver.client.SubscriptionListener;
-import org.eclipse.emfcloud.modelserver.client.v1.ModelServerClientV1;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeePackage;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.edit.command.SetCommandContribution;
@@ -57,7 +57,7 @@ public final class ExampleModelServerClient {
 
    public static void main(final String[] args) {
       try (
-         ModelServerClientV1 client = new ModelServerClientV1("http://localhost:8081/api/v1/",
+         ModelServerClient client = new ModelServerClient("http://localhost:8081/api/v2/",
             new CoffeePackageConfiguration());
          Scanner userInput = new Scanner(System.in)) {
          System.out.println("Simple Model Server Client Interface");
@@ -125,19 +125,19 @@ public final class ExampleModelServerClient {
 
    }
 
-   private static void handleRedo(final ModelServerClientV1 client, final String[] commandAndArgs)
+   private static void handleRedo(final ModelServerClient client, final String[] commandAndArgs)
       throws InterruptedException, ExecutionException, TimeoutException {
       Response<Boolean> response = client.redo(commandAndArgs[1]).join();
       System.out.println("< " + toString(response));
    }
 
-   private static void handleUndo(final ModelServerClientV1 client, final String[] commandAndArgs)
+   private static void handleUndo(final ModelServerClient client, final String[] commandAndArgs)
       throws InterruptedException, ExecutionException, TimeoutException {
       Response<Boolean> response = client.undo(commandAndArgs[1]).join();
       System.out.println("< " + toString(response));
    }
 
-   private static void handleRenameWorkflow(final ModelServerClientV1 client, final String[] commandAndArgs)
+   private static void handleRenameWorkflow(final ModelServerClient client, final String[] commandAndArgs)
       throws InterruptedException, ExecutionException, TimeoutException {
       CCommand command = SetCommandContribution.clientCommand(
          CommandUtil.createProxy(CoffeePackage.Literals.WORKFLOW, "SuperBrewer3000.coffee#//@workflows.0"),
@@ -147,21 +147,21 @@ public final class ExampleModelServerClient {
       System.out.println("< " + toString(response));
    }
 
-   private static void handleUpdateTasks(final ModelServerClientV1 client, final String[] commandAndArgs)
+   private static void handleUpdateTasks(final ModelServerClient client, final String[] commandAndArgs)
       throws InterruptedException, ExecutionException, TimeoutException {
       CCommand command = UpdateTaskNameCommandContribution.clientCommand(commandAndArgs[1]);
       Response<Boolean> response = client.edit(SUPER_BREWER_3000_JSON, command, FORMAT_JSON_V2).join();
       System.out.println("< " + toString(response));
    }
 
-   private static void handleGet(final ModelServerClientV1 client, final String[] commandAndArgs)
+   private static void handleGet(final ModelServerClient client, final String[] commandAndArgs)
       throws InterruptedException, ExecutionException, TimeoutException, IOException {
       Response<String> response = client.get(commandAndArgs[1]).join();
       System.out.println("< " + commandAndArgs[1]);
       System.out.println(Json.parse(response.body()).toPrettyString());
    }
 
-   private static void handleGetAll(final ModelServerClientV1 client, final String[] commandAndArgs)
+   private static void handleGetAll(final ModelServerClient client, final String[] commandAndArgs)
       throws InterruptedException, ExecutionException, TimeoutException, IOException {
       String format = commandAndArgs.length > 1 ? commandAndArgs[1] : null;
       if (format == null) {
@@ -181,25 +181,25 @@ public final class ExampleModelServerClient {
       }
    }
 
-   private static void handleSubscribe(final ModelServerClientV1 client, final String[] command)
+   private static void handleSubscribe(final ModelServerClient client, final String[] command)
       throws InterruptedException {
       String modelUri = command.length > 1 ? command[1] : "";
-      String format = command.length > 2 ? command[2] : "json";
-      SubscriptionListener listener = format.contentEquals("json")
-         ? new ExampleJsonStringSubscriptionListener(modelUri)
-         : new ExampleXMISubscriptionListener(modelUri);
+      String format = command.length > 2 ? command[2] : FORMAT_JSON_V2;
+      SubscriptionListener listener = format.contentEquals(FORMAT_XMI)
+         ? new ExampleXMISubscriptionListener(modelUri)
+         : new ExampleJsonStringSubscriptionListener(modelUri);
       client.subscribe(modelUri, listener, format);
       System.out.println("< OK");
    }
 
-   private static void handleUnsubscribe(final ModelServerClientV1 client, final String[] command)
+   private static void handleUnsubscribe(final ModelServerClient client, final String[] command)
       throws InterruptedException {
       String modelUri = command.length >= 1 ? command[1] : "";
       client.unsubscribe(modelUri);
       System.out.println("< OK");
    }
 
-   private static void handlePing(final ModelServerClientV1 client)
+   private static void handlePing(final ModelServerClient client)
       throws InterruptedException {
       client.ping().thenAccept(response -> System.out.println("< " + response.body()));
    }

--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
@@ -10,6 +10,9 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.example.client;
 
+import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2.FORMAT_JSON_V2;
+import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2.FORMAT_XMI;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.List;
@@ -76,11 +79,11 @@ public final class ExampleModelServerClient {
                String[] commandAndArgs = input.split(" ");
                String command = commandAndArgs[0];
                if (command.contentEquals("1")) {
-                  handleSubscribe(client, new String[] { CMD_SUBSCRIBE, SUPER_BREWER_3000_COFFEE, "json" });
+                  handleSubscribe(client, new String[] { CMD_SUBSCRIBE, SUPER_BREWER_3000_COFFEE, FORMAT_JSON_V2 });
                } else if (command.contentEquals("2")) {
-                  handleSubscribe(client, new String[] { CMD_SUBSCRIBE, SUPER_BREWER_3000_JSON, "json" });
+                  handleSubscribe(client, new String[] { CMD_SUBSCRIBE, SUPER_BREWER_3000_JSON, FORMAT_JSON_V2 });
                } else if (command.contentEquals("3")) {
-                  handleSubscribe(client, new String[] { CMD_SUBSCRIBE, COFFEE_ECORE, "xmi" });
+                  handleSubscribe(client, new String[] { CMD_SUBSCRIBE, COFFEE_ECORE, FORMAT_XMI });
                } else if (command.contentEquals("4")) {
                   handleUnsubscribe(client, new String[] { CMD_UNSUBSCRIBE, SUPER_BREWER_3000_COFFEE });
                } else if (command.contentEquals("5")) {
@@ -140,14 +143,14 @@ public final class ExampleModelServerClient {
          CommandUtil.createProxy(CoffeePackage.Literals.WORKFLOW, "SuperBrewer3000.coffee#//@workflows.0"),
          EcorePackage.Literals.ENAMED_ELEMENT__NAME,
          commandAndArgs[1]);
-      Response<Boolean> response = client.edit(SUPER_BREWER_3000_COFFEE, command, null).join();
+      Response<Boolean> response = client.edit(SUPER_BREWER_3000_COFFEE, command, FORMAT_JSON_V2).join();
       System.out.println("< " + toString(response));
    }
 
    private static void handleUpdateTasks(final ModelServerClientV1 client, final String[] commandAndArgs)
       throws InterruptedException, ExecutionException, TimeoutException {
       CCommand command = UpdateTaskNameCommandContribution.clientCommand(commandAndArgs[1]);
-      Response<Boolean> response = client.edit(SUPER_BREWER_3000_JSON, command, null).join();
+      Response<Boolean> response = client.edit(SUPER_BREWER_3000_JSON, command, FORMAT_JSON_V2).join();
       System.out.println("< " + toString(response));
    }
 


### PR DESCRIPTION
Split implementations of v1 and v2 APIs via delegation to a common partial implementation instead of inheritance of a common partial implementation in

- the `ModelServerClient` API
- the `ModelServerRouting` handlers

The previously existing abstract base classes are deleted (actually, more or less renamed and moved) instead of deprecated because they were only actually introduced during this release in PR #151, so there is no concern about breaking API for downstream applications.

Fixes #168.

Contributed on behalf of STMicroelectronics.