### PR TITLE
Fix #174 API v2: Injection of JsonPatchHelper

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/codecs/Codec.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/codecs/Codec.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,4 +24,27 @@ public interface Codec {
    Optional<EObject> decode(String payload) throws DecodingException;
 
    Optional<EObject> decode(String payload, URI workspaceURI) throws DecodingException;
+
+   //
+   // Nested types
+   //
+
+   /**
+    * An internal interface that may be implemented by codecs to provide protected access
+    * to it within the framework. This interface is not intended for use only by the core
+    * server framework.
+    */
+   interface Internal extends Codec {
+      /**
+       * Encode an object as it is, <em>in situ</em>, without making any temporary
+       * changes to it or operating on a copy, etc.
+       *
+       * @param eObject an object to encode
+       * @return the most direct encoding of the object that is feasible
+       *
+       * @throws EncodingException on failure to perform the encoding
+       */
+      JsonNode basicEncode(EObject eObject) throws EncodingException;
+   }
+
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/codecs/DefaultJsonCodec.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/codecs/DefaultJsonCodec.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class DefaultJsonCodec implements Codec {
+public class DefaultJsonCodec implements Codec.Internal {
 
    private final EMFJsonConverter emfJsonConverter;
 
@@ -47,7 +47,12 @@ public class DefaultJsonCodec implements Codec {
       JsonResource resource = new JsonResource(URI.createURI("$marshall.res"), getObjectMapper());
       resource.getContents().add(EcoreUtil.copy(obj));
 
-      return encode(resource.getContents().get(0), getObjectMapper());
+      return basicEncode(resource.getContents().get(0));
+   }
+
+   @Override
+   public final JsonNode basicEncode(final EObject obj) throws EncodingException {
+      return encode(obj, getObjectMapper());
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultTransactionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultTransactionController.java
@@ -40,7 +40,6 @@ import org.eclipse.emfcloud.modelserver.edit.util.CommandUtil;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.common.util.ContextRequest;
 import org.eclipse.emfcloud.modelserver.emf.common.util.Message;
-import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.patch.PatchCommandHandler;
 import org.eclipse.emfcloud.modelserver.emf.util.JsonPatchHelper;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
@@ -66,7 +65,6 @@ public class DefaultTransactionController implements TransactionController {
 
    protected final ModelRepository modelRepository;
    protected final SessionController sessionController;
-   protected final ServerConfiguration serverConfiguration;
    protected final ModelResourceManager modelResourceManager;
    protected final ObjectMapper objectMapper;
    protected final CodecsManager codecs;
@@ -78,18 +76,16 @@ public class DefaultTransactionController implements TransactionController {
 
    @Inject
    public DefaultTransactionController(final ModelRepository modelRepository, final SessionController sessionController,
-      final ServerConfiguration serverConfiguration, final ModelResourceManager modelResourceManager,
-      final CodecsManager codecs, final ObjectMapper objectMapper,
-      final PatchCommandHandler.Registry patchCommandHandlerRegistry) {
+      final ModelResourceManager modelResourceManager, final CodecsManager codecs, final ObjectMapper objectMapper,
+      final PatchCommandHandler.Registry patchCommandHandlerRegistry, final JsonPatchHelper jsonPatchHelper) {
 
       this.modelRepository = modelRepository;
       this.sessionController = sessionController;
-      this.serverConfiguration = serverConfiguration;
       this.modelResourceManager = modelResourceManager;
       this.codecs = codecs;
       this.objectMapper = objectMapper;
       this.patchCommandHandlerRegistry = patchCommandHandlerRegistry;
-      this.jsonPatchHelper = new JsonPatchHelper(modelResourceManager, serverConfiguration);
+      this.jsonPatchHelper = jsonPatchHelper;
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/RecordingModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/RecordingModelResourceManager.java
@@ -23,8 +23,10 @@ import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatchersManager
 import org.eclipse.emfcloud.modelserver.emf.configuration.ChangePackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+import org.eclipse.emfcloud.modelserver.emf.util.JsonPatchHelper;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 /**
  * A custom implementation of the resource manager that records the changes when executing commands on the command
@@ -35,8 +37,9 @@ public class RecordingModelResourceManager extends DefaultModelResourceManager {
    @Inject
    public RecordingModelResourceManager(final Set<EPackageConfiguration> configurations,
       final AdapterFactory adapterFactory,
-      final ServerConfiguration serverConfiguration, final ModelWatchersManager watchersManager) {
-      super(configurations, adapterFactory, serverConfiguration, watchersManager);
+      final ServerConfiguration serverConfiguration, final ModelWatchersManager watchersManager,
+      final Provider<JsonPatchHelper> jsonPatchHelper) {
+      super(configurations, adapterFactory, serverConfiguration, watchersManager, jsonPatchHelper);
    }
 
    @Override

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2021-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,7 +37,9 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
+import org.eclipse.emfcloud.modelserver.common.utils.MapBinding;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.AbstractResourceTest;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelRepository;
@@ -48,6 +50,7 @@ import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EcorePackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+import org.eclipse.emfcloud.modelserver.emf.di.MultiBindingDefaults;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -114,6 +117,7 @@ public class FileModelWatcherIntegrationTest extends AbstractResourceTest {
 
          private Multibinder<ModelWatcher.Factory> watcherFactoryBinder;
          private Multibinder<EPackageConfiguration> ePackageConfigurationBinder;
+         private MapBinding<String, Codec> codecBinding;
 
          @Override
          protected void configure() {
@@ -122,6 +126,10 @@ public class FileModelWatcherIntegrationTest extends AbstractResourceTest {
 
             watcherFactoryBinder = Multibinder.newSetBinder(binder(), ModelWatcher.Factory.class);
             watcherFactoryBinder.addBinding().to(FileModelWatcher.Factory.class);
+
+            codecBinding = MapBinding.create(String.class, Codec.class);
+            codecBinding.putAll(MultiBindingDefaults.DEFAULT_CODECS);
+            codecBinding.applyBinding(binder());
 
             bind(ServerConfiguration.class).toInstance(serverConfig);
             bind(CommandCodec.class).toInstance(commandCodec);


### PR DESCRIPTION
Inject the `JsonPatchHelper` also into the resource manager and transaction controller that previously constructed it for themselves.

This requires additionally:

- provider injection for the resource manager because the patch helper depends on the resource manager
- configuration of injectors in tests now needs to include injection of codecs map because it is injected into the patch helper

So far, this is tied to `json-v2` format exclusively as this is the default format for API v2. If the helper should need to pick up other formats from the request/socket context, then that's an orthogonal issue.

Contributed on behalf of STMicroelectronics.