### PR TITLE
Fix #155: Consistent handling of URIs

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: com.fasterxml.jackson.core.jackson-core;bundle-version="[2.9.0,3
  org.eclipse.emf.edit;bundle-version="[2.16.0,3.0.0)"
 Export-Package: org.eclipse.emfcloud.modelserver.common,
  org.eclipse.emfcloud.modelserver.common.codecs,
+ org.eclipse.emfcloud.modelserver.common.di,
  org.eclipse.emfcloud.modelserver.common.patch,
  org.eclipse.emfcloud.modelserver.common.utils,
  org.eclipse.emfcloud.modelserver.jsonschema

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/APIVersion.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/APIVersion.java
@@ -1,0 +1,152 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common;
+
+import java.util.Objects;
+
+/**
+ * A version of the Model Server API.
+ */
+public final class APIVersion implements Comparable<APIVersion> {
+
+   public static final APIVersion ZERO = new APIVersion(0, 0, 0);
+
+   private final int major;
+
+   private final int minor;
+
+   private final int patch;
+
+   private final int hash;
+
+   public APIVersion(final int major, final int minor, final int patch) {
+      super();
+
+      if (major < 0) {
+         throw new IllegalArgumentException("negative major version");
+      }
+      if (minor < 0) {
+         throw new IllegalArgumentException("negative minor version");
+      }
+      if (patch < 0) {
+         throw new IllegalArgumentException("negative patch version");
+      }
+
+      this.major = major;
+      this.minor = minor;
+      this.patch = patch;
+
+      this.hash = Objects.hash(major, minor, patch);
+   }
+
+   public APIVersion(final int major, final int minor) {
+      this(major, minor, 0);
+   }
+
+   public APIVersion(final int major) {
+      this(major, 0, 0);
+   }
+
+   public int major() {
+      return major;
+   }
+
+   public int minor() {
+      return minor;
+   }
+
+   public int patch() {
+      return patch;
+   }
+
+   /**
+    * Create an unbounded range with myself as the closed lower bound.
+    */
+   public APIVersionRange range() {
+      return new APIVersionRange(this);
+   }
+
+   /**
+    * Create range with myself as the closed lower bound up to but not including
+    * the given upper bound.
+    */
+   public APIVersionRange range(final APIVersion to) {
+      return new APIVersionRange(this, false, to, true);
+   }
+
+   /**
+    * Create range with myself as the closed lower bound up to and including
+    * the given upper bound.
+    */
+   public APIVersionRange rangeInclusive(final APIVersion to) {
+      return new APIVersionRange(this, false, to, false);
+   }
+
+   public boolean lessThan(final APIVersion other) {
+      return this.compareTo(other) < 0;
+   }
+
+   public boolean lessThanOrEqual(final APIVersion other) {
+      return this.compareTo(other) <= 0;
+   }
+
+   public boolean greaterThan(final APIVersion other) {
+      return this.compareTo(other) > 0;
+   }
+
+   public boolean greaterThanOrEqual(final APIVersion other) {
+      return this.compareTo(other) >= 0;
+   }
+
+   @Override
+   public int compareTo(final APIVersion o) {
+      int result = major - o.major;
+      if (result == 0) {
+         result = minor - o.minor;
+         if (result == 0) {
+            result = patch - o.patch;
+         }
+      }
+      return result;
+   }
+
+   @Override
+   public int hashCode() {
+      return hash;
+   }
+
+   @Override
+   public boolean equals(final Object obj) {
+      if (!(obj instanceof APIVersion)) {
+         return false;
+      }
+      APIVersion other = (APIVersion) obj;
+      return other.major == major && other.minor == minor && other.patch == patch;
+   }
+
+   @Override
+   public String toString() {
+      return String.format("%s.%s.%s", major, minor, patch);
+   }
+
+   public static APIVersion of(final int major) {
+      return new APIVersion(major);
+   }
+
+   public static APIVersion of(final int major, final int minor) {
+      return new APIVersion(major, minor);
+   }
+
+   public static APIVersion of(final int major, final int minor, final int patch) {
+      return new APIVersion(major, minor, patch);
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/APIVersionRange.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/APIVersionRange.java
@@ -1,0 +1,160 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common;
+
+import java.util.Objects;
+
+/**
+ * A range of versions of the Model Server API. A version range may be open (exclusive) or
+ * closed (inclusive) on either end. It may be unbounded on the upper end, in which case it
+ * is open (exclusive) on that end. The lower end may not be unbounded.
+ */
+public final class APIVersionRange implements Comparable<APIVersionRange> {
+
+   public static final APIVersionRange ANY = APIVersion.ZERO.range();
+
+   private final APIVersion lower;
+
+   private final boolean lowerOpen;
+
+   private final APIVersion upper;
+
+   private final boolean upperOpen;
+
+   private final int hash;
+
+   public APIVersionRange(final APIVersion lower, final boolean lowerOpen, final APIVersion upper,
+      final boolean upperOpen) {
+
+      super();
+
+      if (lower == null) {
+         throw new IllegalArgumentException("lower bound is required");
+      }
+      if (upper == null && !upperOpen) {
+         throw new IllegalArgumentException("unlimited upper bound must be open");
+      }
+
+      this.lower = lower;
+      this.lowerOpen = lowerOpen;
+      this.upper = upper;
+      this.upperOpen = upperOpen;
+
+      this.hash = Objects.hash(lower, lowerOpen, upper, upperOpen);
+   }
+
+   /** Create a range unbounded at the open end. */
+   public APIVersionRange(final APIVersion lower, final boolean lowerOpen) {
+      this(lower, lowerOpen, null, true);
+   }
+
+   /** Create a range closed at the {@code lower} bound and unbounded at the upper end. */
+   public APIVersionRange(final APIVersion lower) {
+      this(lower, false, null, true);
+   }
+
+   public APIVersion lower() {
+      return lower;
+   }
+
+   public boolean lowerOpen() {
+      return lowerOpen;
+   }
+
+   public APIVersion upper() {
+      return upper;
+   }
+
+   public boolean upperOpen() {
+      return upperOpen;
+   }
+
+   public boolean isUnbounded() { return upper == null; }
+
+   public boolean includes(final APIVersion version) {
+      return (lowerOpen ? lower.lessThan(version) : lower.lessThanOrEqual(version))
+         && (isUnbounded() || (upperOpen ? upper.greaterThan(version) : upper.greaterThanOrEqual(version)));
+   }
+
+   /**
+    * Is my lower bound greater than another {@code range}'s, accounting for openness?
+    *
+    * @param range another range
+    * @return {@code true} if my lower bound is greater than {@code range}'s or it is an open bound where
+    *         {@code range}'s is closed; {@code false}, otherwise
+    */
+   public boolean lowerBoundGreaterThan(final APIVersionRange range) {
+      if (lower.greaterThan(range.lower)) {
+         return true;
+      }
+      if (lower.equals(range.lower)) {
+         // An open lower bound is greater than a closed lower bound
+         return lowerOpen && !range.lowerOpen;
+      }
+      return false;
+   }
+
+   @Override
+   public int compareTo(final APIVersionRange o) {
+      // First compare by lower bound
+      int result = lower.compareTo(o.lower);
+      if (result == 0) {
+         // Sort closed-at-the-lower-bound ranges before open-at-the-lower-bound
+         result = Boolean.compare(lowerOpen, o.lowerOpen);
+      }
+
+      if (result == 0) {
+         // Then compare by upper bound. Take care of unbounded cases
+         result = Boolean.compare(isUnbounded(), o.isUnbounded());
+         if (result == 0 && !isUnbounded()) {
+            result = upper.compareTo(o.upper);
+            if (result == 0) {
+               // Sort open-at-the-upper-bound ranges before closed-at-the-upper-bound
+               result = Boolean.compare(o.upperOpen, upperOpen);
+            }
+         }
+      }
+
+      return result;
+   }
+
+   @Override
+   public int hashCode() {
+      return hash;
+   }
+
+   @Override
+   public boolean equals(final Object obj) {
+      if (!(obj instanceof APIVersionRange)) {
+         return false;
+      }
+      APIVersionRange other = (APIVersionRange) obj;
+      return lower.equals(other.lower) && Objects.equals(upper, other.upper)
+         && lowerOpen == other.lowerOpen && upperOpen == other.upperOpen;
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder result = new StringBuilder();
+      result.append(lowerOpen ? '(' : '[');
+      result.append(lower);
+      result.append(',');
+      if (isUnbounded()) {
+         result.append(')');
+      } else {
+         result.append(' ');
+         result.append(upper);
+         result.append(upperOpen ? ')' : ']');
+      }
+      return result.toString();
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/di/AbstractModuleWithInitializers.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/di/AbstractModuleWithInitializers.java
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common.di;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.matcher.Matchers;
+
+/**
+ * An abstract module to subclass to get support for post-injection invocation
+ * of {@link Initialize @Initialize} methods.
+ */
+public class AbstractModuleWithInitializers extends AbstractModule {
+
+   @Override
+   protected void configure() {
+      bindListener(Matchers.any(), new InitializerSupport());
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/di/Initialize.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/di/Initialize.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common.di;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Annotation for a method to be invoked by the Guice Injector after the object has
+ * been created and all member injections are performed. This provides a post-injection
+ * initialization hook in which the object can be assured of all its dependencies being
+ * available.
+ * </p>
+ * <p>
+ * It is an error for an initialization method to have parameters. All dependencies
+ * should be injected prior to invocation of the initializer. If the initializer has
+ * parameters, an exception will be thrown at run-time.
+ * </p>
+ * <p>
+ * Initializers are called in superclass order from top to bottom of the class hierarchy.
+ * If a class overrides the initializer method of a superclass and the overriding method
+ * is itself annotated with {@code @Initialize}, then the method is only called once.
+ * But the overriding method needs not have the annotation because it will be invoked
+ * via the superclass.
+ * </p>
+ * <p>
+ * At most one method of a class, not considering* inheritance, may be designated as
+ * an initializer.
+ * </p>
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Initialize {
+   // Empty annotation
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/di/InitializerSupport.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/di/InitializerSupport.java
@@ -1,0 +1,200 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common.di;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.inject.ConfigurationException;
+import com.google.inject.ProvisionException;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.Message;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+
+/**
+ * Support for installation of the Guice hooks for post-injection object initialization
+ * via {@link Initialize @Initialize} methods.
+ */
+public final class InitializerSupport implements TypeListener {
+
+   private final InjectionListener<Object> listener = this::afterInjection;
+
+   private final Map<Class<?>, Initializer> initializers = new HashMap<>();
+
+   public InitializerSupport() {
+      super();
+   }
+
+   @Override
+   public <I> void hear(final TypeLiteral<I> type, final TypeEncounter<I> encounter) {
+      encounter.register(listener);
+   }
+
+   private void afterInjection(final Object injectee) {
+      Initializer initializer = getInitializer(injectee);
+      if (initializer != null) {
+         initializer.initialize(injectee);
+      }
+   }
+
+   private Initializer getInitializer(final Object object) {
+      return getInitializerForClass(object.getClass());
+   }
+
+   private Initializer getInitializerForClass(final Class<?> clazz) {
+      if (clazz == null) {
+         // Object has no superclass
+         return null;
+      }
+
+      Initializer result = initializers.get(clazz);
+      if (result == null) {
+         result = createInitializer(clazz);
+         if (result == null) {
+            result = Initializer.NULL;
+         }
+         initializers.put(clazz, result);
+      }
+
+      return result == Initializer.NULL ? null : result;
+   }
+
+   private Initializer createInitializer(final Class<?> clazz) {
+      Initializer baseInitializer = getInitializerForClass(clazz.getSuperclass());
+
+      Method initializeMethod = findInitializeMethod(clazz);
+      if (initializeMethod == null || (baseInitializer != null && baseInitializer.overriddenBy(initializeMethod))) {
+         // Overriding the method and maintaining the annotation? Superclass initializer will suffice
+         return baseInitializer;
+      }
+
+      return new Initializer(initializeMethod).after(baseInitializer);
+   }
+
+   private Method findInitializeMethod(final Class<?> clazz) {
+      Method result = null;
+      List<Message> messages = new ArrayList<>(2);
+      boolean multipleMessage = false;
+
+      for (Method method : clazz.getDeclaredMethods()) {
+         if (method.isAnnotationPresent(Initialize.class)) {
+            if (result != null) {
+               if (!multipleMessage) {
+                  messages.add(new Message(clazz,
+                     "Multiple methods annotated with @Initialize in class " + clazz.getCanonicalName()));
+                  multipleMessage = true;
+               }
+            } else {
+               result = method;
+            }
+
+            if (method.getParameterCount() > 0) {
+               messages.add(
+                  new Message(method, "@Initialize method " + method.getName() + "must not have parameters in class "
+                     + clazz.getCanonicalName()));
+            }
+         }
+      }
+
+      if (!messages.isEmpty()) {
+         throw new ConfigurationException(messages);
+      }
+
+      return result;
+   }
+
+   //
+   // Nested types
+   //
+
+   private static final class Initializer {
+      static final Initializer NULL = new Initializer(null);
+
+      private final Method initializeMethod;
+      private Initializer before;
+
+      Initializer(final Method initializeMethod) {
+         super();
+
+         this.initializeMethod = initializeMethod;
+      }
+
+      @SuppressWarnings("checkstyle:IllegalCatch")
+      void initialize(final Object target) {
+         try {
+            if (before != null) {
+               before.initialize(target);
+            }
+
+            doInitialize(target);
+         } catch (ProvisionException e) {
+            throw e;
+         } catch (IllegalAccessException e) {
+            throw new ProvisionException("Inaccessible @Initialize method", e);
+         } catch (IllegalArgumentException e) {
+            throw new ProvisionException("Invalid @Initialize method", e);
+         } catch (InvocationTargetException | RuntimeException e) {
+            throw new ProvisionException("@Initialize method failed with an exception", e);
+         }
+      }
+
+      private void doInitialize(final Object target)
+         throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+         if (initializeMethod != null && !initializeMethod.canAccess(target)) {
+            initializeMethod.setAccessible(true);
+         }
+
+         initializeMethod.invoke(target);
+      }
+
+      Initializer after(final Initializer before) {
+         if (before != NULL) {
+            this.before = before;
+         }
+         return this;
+      }
+
+      boolean overriddenBy(final Method subclassMethod) {
+         return initializeMethod != null && subclassMethod.getName().equals(initializeMethod.getName())
+            && canOverride(subclassMethod, initializeMethod);
+      }
+
+      private static boolean canOverride(final Method subclassMethod, final Method superclassMethod) {
+         int subclassModifiers = subclassMethod.getModifiers();
+         int superclassModifiers = superclassMethod.getModifiers();
+
+         if (Modifier.isPrivate(superclassModifiers) || Modifier.isPrivate(subclassModifiers)) {
+            // Private methods cannot be involved in overrides
+            return false;
+         }
+
+         if (Modifier.isPublic(subclassModifiers)) {
+            // Public methods always override if they can
+            return true;
+         }
+
+         if (Modifier.isProtected(superclassModifiers) && Modifier.isPrivate(subclassModifiers)) {
+            return true;
+         }
+
+         return Objects.equals(subclassMethod.getDeclaringClass().getPackage(),
+            superclassMethod.getDeclaringClass().getPackage());
+      }
+   }
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/utils/APIVersionMap.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/utils/APIVersionMap.java
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common.utils;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.eclipse.emfcloud.modelserver.common.APIVersion;
+import org.eclipse.emfcloud.modelserver.common.APIVersionRange;
+
+/**
+ * A specialized map that keys values by API version ranges. It provides accessors
+ * to look up values by version, returning the first value from a range that includes
+ * the requested version. Entries in the map are sorted such that a version look-up
+ * will match the range with the least lower bound and least upper bound that span it.
+ *
+ * @param <T> the mapped value type
+ */
+public final class APIVersionMap<T> extends TreeMap<APIVersionRange, T> {
+
+   private static final long serialVersionUID = 1L;
+
+   public APIVersionMap() {
+      super();
+   }
+
+   public APIVersionMap(final Map<APIVersionRange, ? extends T> map) {
+      this();
+
+      putAll(map);
+   }
+
+   /**
+    * Get the value for the first range that matches the given {@code version}.
+    *
+    * @param version an API version to look up
+    * @return the matching value, or {@code null} if no value is mapped by a range that includes the {@code version}
+    */
+   public T get(final APIVersion version) {
+      return getOrDefault(version, null);
+   }
+
+   /**
+    * Get the value for the first range that matches the given {@code version} or else some default.
+    *
+    * @param version an API version to look up
+    * @return the matching value, or {@code defaultValue} if no value is mapped by a range that includes the
+    *         {@code version}
+    */
+   public T getOrDefault(final APIVersion version, final T defaultValue) {
+      // Find the narrowest range that includes the version. Narrowest is not
+      // literally the narrowest because we don't have a measure of the magnitude
+      // of a version number, but it's the first one that has the greatest lower bound
+      // that includes the version (ranges with the same lower bound ordering themselves
+      // by upper bound)
+      APIVersionRange narrowest = null;
+
+      for (Map.Entry<APIVersionRange, T> next : entrySet()) {
+         APIVersionRange range = next.getKey();
+         if (range.includes(version)) {
+            if (narrowest == null || range.lowerBoundGreaterThan(narrowest)) {
+               narrowest = range;
+            }
+         } else if (range.lower().greaterThan(version)) {
+            // No subsequent ranges can include this version
+            break;
+         }
+      }
+
+      return narrowest == null ? defaultValue : get(narrowest);
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/META-INF/MANIFEST.MF
@@ -22,11 +22,14 @@ Require-Bundle: com.fasterxml.jackson.core.jackson-core;bundle-version="[2.9.0,3
  org.aopalliance;bundle-version="1.0.0"
 Export-Package: org.eclipse.emfcloud.modelserver.emf.common,
  org.eclipse.emfcloud.modelserver.emf.common.codecs,
+ org.eclipse.emfcloud.modelserver.emf.common.codecs.jackson,
  org.eclipse.emfcloud.modelserver.emf.common.util,
  org.eclipse.emfcloud.modelserver.emf.common.watchers,
  org.eclipse.emfcloud.modelserver.emf.configuration,
  org.eclipse.emfcloud.modelserver.emf.di,
- org.eclipse.emfcloud.modelserver.emf.launch
+ org.eclipse.emfcloud.modelserver.emf.launch,
+ org.eclipse.emfcloud.modelserver.emf.patch,
+ org.eclipse.emfcloud.modelserver.emf.util
 Import-Package: com.fasterxml.jackson.annotation;version="2.9.9",
  com.github.fge.jsonpatch.diff;version="1.3.0",
  com.google.inject.multibindings;version="1.3.0",

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
@@ -27,19 +27,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
-import org.eclipse.emfcloud.modelserver.command.util.CommandSwitch;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV1;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
@@ -75,6 +71,7 @@ public class DefaultModelController implements ModelController {
    protected final CodecsManager codecs;
    protected final ModelValidator modelValidator;
    protected final PatchCommandHandler.Registry commandHandlerRegistry;
+   protected final ModelURIConverter uriConverter;
    protected final JsonPatchHelper jsonPatchHelper;
 
    @Inject
@@ -82,13 +79,14 @@ public class DefaultModelController implements ModelController {
    public DefaultModelController(final ModelRepository modelRepository, final SessionController sessionController,
       final ServerConfiguration serverConfiguration, final CodecsManager codecs, final ModelValidator modelValidator,
       final PatchCommandHandler.Registry commandHandlerRegistry, final ModelResourceManager resourceManager,
-      final JsonPatchHelper jsonPatchHelper) {
+      final ModelURIConverter uriConverter, final JsonPatchHelper jsonPatchHelper) {
       this.modelRepository = modelRepository;
       this.sessionController = sessionController;
       this.serverConfiguration = serverConfiguration;
       this.codecs = codecs;
       this.modelValidator = modelValidator;
       this.commandHandlerRegistry = commandHandlerRegistry;
+      this.uriConverter = uriConverter;
       this.jsonPatchHelper = jsonPatchHelper;
    }
 
@@ -120,7 +118,7 @@ public class DefaultModelController implements ModelController {
       if (this.modelRepository.hasModel(modeluri)) {
          try {
             this.modelRepository.deleteModel(modeluri);
-            success(ctx, "Model '%s' successfully deleted", modeluri);
+            success(ctx, "Model '%s' successfully deleted", uriConverter.deresolveModelURI(ctx, modeluri));
             this.sessionController.modelDeleted(modeluri);
          } catch (IOException e) {
             internalError(ctx, e);
@@ -134,7 +132,7 @@ public class DefaultModelController implements ModelController {
    public void close(final Context ctx, final String modeluri) {
       if (this.modelRepository.hasModel(modeluri)) {
          this.modelRepository.closeModel(modeluri);
-         success(ctx, "Model '%s' successfully closed", modeluri);
+         success(ctx, "Model '%s' successfully closed", uriConverter.deresolveModelURI(ctx, modeluri));
          this.sessionController.modelClosed(modeluri);
       } else {
          ContextResponse.modelNotFound(ctx, modeluri);
@@ -148,7 +146,7 @@ public class DefaultModelController implements ModelController {
          Map<URI, JsonNode> encodedEntries = Maps.newLinkedHashMap();
          for (Map.Entry<URI, EObject> entry : allModels.entrySet()) {
             final JsonNode encoded = codecs.encode(ctx, entry.getValue());
-            encodedEntries.put(entry.getKey(), encoded);
+            encodedEntries.put(uriConverter.deresolveModelURI(ctx, entry.getKey()), encoded);
          }
          success(ctx, JsonCodec.encode(encodedEntries));
       } catch (EncodingException exception) {
@@ -176,7 +174,8 @@ public class DefaultModelController implements ModelController {
    public void getModelElementById(final Context ctx, final String modeluri, final String elementid) {
       Optional<EObject> element = this.modelRepository.getModelElementById(modeluri, elementid);
       if (element.isEmpty()) {
-         notFound(ctx, "Element with id '" + elementid + "' of model '" + modeluri + "' not found!");
+         notFound(ctx, "Element with id '" + elementid + "' of model '" + uriConverter.deresolveModelURI(ctx, modeluri)
+            + "' not found!");
          return;
       }
       try {
@@ -190,7 +189,8 @@ public class DefaultModelController implements ModelController {
    public void getModelElementByName(final Context ctx, final String modeluri, final String elementname) {
       Optional<EObject> element = this.modelRepository.getModelElementByName(modeluri, elementname);
       if (element.isEmpty()) {
-         notFound(ctx, "Element with name '" + elementname + "' of model '" + modeluri + "' not found!");
+         notFound(ctx, "Element with name '" + elementname + "' of model '"
+            + uriConverter.deresolveModelURI(ctx, modeluri) + "' not found!");
          return;
       }
       try {
@@ -221,15 +221,16 @@ public class DefaultModelController implements ModelController {
 
    @Override
    public void save(final Context ctx, final String modeluri) {
+      String model = uriConverter.deresolveModelURI(ctx, modeluri);
       if (!this.modelRepository.hasModel(modeluri)) {
-         notFound(ctx, "Model '%s' not found.", modeluri);
+         notFound(ctx, "Model '%s' not found.", model);
          return;
       }
       if (this.modelRepository.saveModel(modeluri)) {
-         success(ctx, "Model '%s' successfully saved", modeluri);
+         success(ctx, "Model '%s' successfully saved", model);
          sessionController.modelSaved(modeluri);
       } else {
-         internalError(ctx, "Saving model '%s' failed!", modeluri);
+         internalError(ctx, "Saving model '%s' failed!", model);
       }
    }
 
@@ -300,11 +301,25 @@ public class DefaultModelController implements ModelController {
    @Override
    public void getModelUris(final Context ctx) {
       try {
-         ctx.json(JsonResponse.success(JsonCodec.encode(this.modelRepository.getRelativeModelUris())));
+         List<String> uris;
+
+         if (ContextRequest.getAPIVersion(ctx).major() < 2) {
+            // Compatibility for API v1
+            uris = getModelURIsV1();
+         } else {
+            uris = this.modelRepository.getAbsoluteModelUris().stream()
+               .map(uri -> uriConverter.deresolveModelURI(ctx, uri))
+               .collect(Collectors.toList());
+         }
+
+         ctx.json(JsonResponse.success(JsonCodec.encode(uris)));
       } catch (EncodingException ex) {
          encodingError(ctx, ex);
       }
    }
+
+   @SuppressWarnings("deprecation")
+   private List<String> getModelURIsV1() { return List.copyOf(this.modelRepository.getRelativeModelUris()); }
 
    protected Optional<EObject> readPayload(final Context ctx) {
       Optional<String> data = ContextRequest.readData(ctx);
@@ -330,7 +345,7 @@ public class DefaultModelController implements ModelController {
          try {
             CCommandExecutionResult execution = modelRepository.executeCommand(modelURI, command.get());
 
-            success(ctx, "Model '%s' successfully updated", modelURI);
+            success(ctx, "Model '%s' successfully updated", uriConverter.deresolveModelURI(ctx, modelURI));
 
             sessionController.commandExecuted(modelURI, Suppliers.ofInstance(execution),
                Suppliers.memoize(() -> getJSONPatchUpdate(ctx, modelURI, root, execution)));
@@ -372,14 +387,15 @@ public class DefaultModelController implements ModelController {
          return;
       }
 
+      String model = uriConverter.deresolveModelURI(ctx, modelURI);
       JsonNode patchResult = getJSONPatchUpdate(ctx, modelURI, root, result);
       if (patchResult != null) {
-         successPatch(ctx, patchResult, "Model '%s' successfully updated", modelURI);
+         successPatch(ctx, patchResult, "Model '%s' successfully updated", model);
 
          sessionController.commandExecuted(modelURI, Suppliers.ofInstance(result),
             Suppliers.ofInstance(patchResult));
       } else {
-         success(ctx, "Model '%s' successfully updated", modelURI);
+         success(ctx, "Model '%s' successfully updated", model);
       }
    }
 
@@ -410,56 +426,10 @@ public class DefaultModelController implements ModelController {
       Object data = pCommand.getData();
       if (data instanceof CCommand) {
          CCommand cCommand = (CCommand) data;
-         resolveWorkspaceURIs(cCommand);
+         // resolveWorkspaceURIs(cCommand);
          return cCommand;
       }
       return null;
-   }
-
-   /**
-    * In V1 (And with the Theia client), clients were expected to include
-    * the complete URIs when referencing EObjects (including the workspace
-    * path prefix). With V2 and standalone client, the client no longer has
-    * knowledge about the workspace location, and may not be able to provide
-    * full URIs. Resolve relative URIs against the current workspace root.
-    *
-    * @param jsonResource
-    */
-   protected void resolveWorkspaceURIs(final CCommand cCommand) {
-      if (serverConfiguration.getWorkspaceRootURI() == null) {
-         return;
-      }
-      TreeIterator<EObject> allContents = cCommand.eAllContents();
-      doResolveWorkspaceURIs(cCommand);
-      while (allContents.hasNext()) {
-         EObject next = allContents.next();
-         new CommandSwitch<Void>() {
-            @Override
-            public Void caseCommand(final CCommand object) {
-               doResolveWorkspaceURIs(object);
-               return null;
-            }
-         }.doSwitch(next);
-      }
-   }
-
-   private void doResolveWorkspaceURIs(final CCommand cCommand) {
-      EObject owner = cCommand.getOwner();
-      List<EObject> objectValues = cCommand.getObjectValues();
-      List<EObject> objectsToAdd = cCommand.getObjectsToAdd();
-      Stream.concat(
-         Stream.concat(
-            Stream.ofNullable(owner),
-            objectValues.stream()),
-         objectsToAdd.stream())
-         .forEach(this::doResolveWorkspaceURIs);
-   }
-
-   private void doResolveWorkspaceURIs(final EObject eObject) {
-      URI objectURI = EcoreUtil.getURI(eObject);
-      if (eObject.eIsProxy() && objectURI.isRelative()) {
-         ((InternalEObject) eObject).eSetProxyURI(objectURI.resolve(serverConfiguration.getWorkspaceRootURI()));
-      }
    }
 
    private ArrayNode getJsonPatch(final PatchCommand<?> pCommand) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelController.java
@@ -426,7 +426,6 @@ public class DefaultModelController implements ModelController {
       Object data = pCommand.getData();
       if (data instanceof CCommand) {
          CCommand cCommand = (CCommand) data;
-         // resolveWorkspaceURIs(cCommand);
          return cCommand;
       }
       return null;

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelRepository.java
@@ -182,6 +182,7 @@ public class DefaultModelRepository implements ModelRepository {
       return modelResourceManager.redo(modeluri);
    }
 
+   @Deprecated
    @Override
    public Set<String> getRelativeModelUris() {
       Set<String> modeluris = new HashSet<>();

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -12,12 +12,15 @@ package org.eclipse.emfcloud.modelserver.emf.common;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -28,13 +31,13 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
+import org.eclipse.emfcloud.modelserver.common.di.Initialize;
 import org.eclipse.emfcloud.modelserver.common.patch.JsonPatchException;
 import org.eclipse.emfcloud.modelserver.common.patch.JsonPatchTestException;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
@@ -56,6 +59,9 @@ import com.google.inject.Provider;
 public class DefaultModelResourceManager implements ModelResourceManager {
    protected static final Logger LOG = LogManager.getLogger(DefaultModelResourceManager.class);
 
+   // A scheme must comprise at least two characters, otherwise it's assumed to be a Windows drive letter
+   protected static final Pattern SCHEME_PATTERN = Pattern.compile("^([a-zA-Z_0-9@-]{2,}):");
+
    @Inject
    protected CommandCodec commandCodec;
 
@@ -70,6 +76,7 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    protected ModelWatchersManager watchersManager;
    protected final Map<URI, ResourceSet> resourceSets = Maps.newLinkedHashMap();
    protected final Map<ResourceSet, ModelServerEditingDomain> editingDomains = Maps.newLinkedHashMap();
+   protected ResourceSetFactory resourceSetFactory;
 
    // Inject a provider to break the dependency cycle (the helper needs the resource manager)
    protected final Provider<JsonPatchHelper> jsonPatchHelper;
@@ -86,10 +93,12 @@ public class DefaultModelResourceManager implements ModelResourceManager {
       this.serverConfiguration = serverConfiguration;
       this.watchersManager = watchersManager;
       this.jsonPatchHelper = jsonPatchHelper;
-
-      initialize();
    }
 
+   // Only initialize after injection of the object. This also avoids the antipattern of invoking
+   // a method from a superclass constructor that can be overridden in subclasses and so "see"
+   // a partially-uninitialized object
+   @Initialize
    @Override
    public void initialize() {
       this.isInitializing = true;
@@ -107,6 +116,11 @@ public class DefaultModelResourceManager implements ModelResourceManager {
       } finally {
          this.isInitializing = false;
       }
+   }
+
+   @Inject
+   public void setResourceSetFactory(final ResourceSetFactory resourceSetFactory) {
+      this.resourceSetFactory = resourceSetFactory;
    }
 
    @Override
@@ -128,8 +142,9 @@ public class DefaultModelResourceManager implements ModelResourceManager {
          if (isSourceDirectory(file)) {
             loadSourceResources(file.getAbsolutePath());
          } else if (file.isFile()) {
-            resourceSets.put(createURI(file.getAbsolutePath()), new ResourceSetImpl());
-            loadResource(file.getAbsolutePath());
+            URI modelURI = createURI(file.getAbsolutePath());
+            resourceSets.put(modelURI, resourceSetFactory.createResourceSet(modelURI));
+            loadResource(modelURI.toString());
          }
       }
    }
@@ -164,9 +179,13 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    }
 
    protected URI createURI(final String modeluri) {
-      return modeluri.startsWith("file:")
-         ? URI.createURI(modeluri, true)
-         : URI.createFileURI(modeluri);
+      Matcher scheme = SCHEME_PATTERN.matcher(modeluri);
+      if (scheme.find() && URI.validScheme(scheme.group(1))) {
+         return URI.createURI(modeluri, true);
+      }
+
+      // It's a file path
+      return URI.createFileURI(modeluri);
    }
 
    /**
@@ -182,13 +201,14 @@ public class DefaultModelResourceManager implements ModelResourceManager {
    public Optional<Resource> loadResource(final String modeluri) {
       try {
          ResourceSet rset = getResourceSet(modeluri);
-         Optional<Resource> loadedResource = Optional.ofNullable(rset.getResource(createURI(modeluri), false))
+         URI resourceURI = createURI(modeluri);
+         Optional<Resource> loadedResource = Optional.ofNullable(rset.getResource(resourceURI, false))
             .filter(Resource::isLoaded);
          if (loadedResource.isPresent()) {
             return loadedResource;
          }
          // do load the resource and watch for modifications
-         Resource resource = rset.getResource(createURI(modeluri), true);
+         Resource resource = rset.getResource(resourceURI, true);
          resource.load(Collections.EMPTY_MAP);
          watchResourceModifications(resource);
          return Optional.of(resource);
@@ -300,7 +320,7 @@ public class DefaultModelResourceManager implements ModelResourceManager {
          if (resourceStillExists) {
             // recreate resource set when necessary
             resourceSets.computeIfAbsent(uri, u -> {
-               ResourceSetImpl created = new ResourceSetImpl();
+               ResourceSet created = resourceSetFactory.createResourceSet(u);
                createEditingDomain(created);
                return created;
             });
@@ -338,9 +358,10 @@ public class DefaultModelResourceManager implements ModelResourceManager {
 
    @Override
    public void addResource(final String modeluri, final EObject model) throws IOException {
-      resourceSets.put(createURI(modeluri), new ResourceSetImpl());
+      URI resourceURI = createURI(modeluri);
+      resourceSets.put(resourceURI, resourceSetFactory.createResourceSet(resourceURI));
       ResourceSet newResourceSet = getResourceSet(modeluri);
-      final Resource resource = newResourceSet.createResource(createURI(modeluri));
+      final Resource resource = newResourceSet.createResource(resourceURI);
       newResourceSet.getResources().add(resource);
       resource.getContents().add(model);
       resource.save(null);
@@ -557,22 +578,30 @@ public class DefaultModelResourceManager implements ModelResourceManager {
     *
     * @param modelUri the client-supplied model URI
     * @return the absolute file URI
+    *
+    * @deprecated Resolution/normalization/etc. of incoming model URIs is the responsibility of the
+    *             {@link ModelURIConverter} service
     */
    @Override
+   @Deprecated
    public String adaptModelUri(final String modelUri) {
-      URI uri = URI.createURI(modelUri, true);
+      URI uri = createURI(modelUri);
+
       if (uri.isRelative()) {
          if (serverConfiguration.getWorkspaceRootURI().isFile()) {
             return uri.resolve(serverConfiguration.getWorkspaceRootURI()).toString();
          }
          return URI.createFileURI(modelUri).toString();
       }
+
       // Create file URI from path if modelUri is already absolute path (file:/ or full path file:///)
       // to ensure consistent usage of org.eclipse.emf.common.util.URI
       if (uri.hasDevice() && !Strings.isNullOrEmpty(uri.device())) {
-         return URI.createFileURI(uri.device() + uri.path()).toString();
+         String path = "/" + Paths.get(uri.device(), uri.path()).toFile().toString();
+         return URI.createFileURI(path).toString();
       }
-      return URI.createFileURI(uri.path()).toString();
+
+      return uri.toString();
    }
 
    public static class CommandExecutionContext {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelURIConverter.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelURIConverter.java
@@ -1,0 +1,260 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import static java.util.function.Function.identity;
+import static java.util.function.Predicate.not;
+import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextRequest.getAPIVersion;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.impl.ExtensibleURIConverterImpl;
+import org.eclipse.emfcloud.modelserver.common.APIVersion;
+import org.eclipse.emfcloud.modelserver.common.APIVersionRange;
+import org.eclipse.emfcloud.modelserver.common.utils.APIVersionMap;
+import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import io.javalin.http.Context;
+import io.javalin.websocket.WsContext;
+
+/**
+ * A URI converter that resolves relative URIs against the Model Server workspace.
+ */
+public class DefaultModelURIConverter extends ExtensibleURIConverterImpl implements ModelURIConverter {
+
+   public static final String MODEL_URI_VALIDATOR = "modelURIValidator";
+
+   public static final String MODEL_URI_RESOLVERS = "modelURIResolvers";
+
+   public static final String MODEL_URI_DERESOLVERS = "modelURIDeresolvers";
+
+   protected static final Pattern SCHEME_PATTERN = Pattern.compile("^([a-zA-Z_0-9@-]+):");
+
+   protected final APIVersionMap<Function<? super URI, Optional<URI>>> modelURIResolvers = new APIVersionMap<>();
+
+   protected final APIVersionMap<Function<? super URI, URI>> modelURIDeresolvers = new APIVersionMap<>();
+
+   protected final ServerConfiguration serverConfiguration;
+
+   @Inject
+   public DefaultModelURIConverter(final ServerConfiguration serverConfiguration) {
+      super();
+
+      this.serverConfiguration = serverConfiguration;
+   }
+
+   @Override
+   public URI normalize(URI uri) {
+      if (uri.isRelative()) {
+         // Resolve relative URIs against the workspace root, not the current working directory
+         uri = uri.resolve(getWorkspaceRootDirectoryURI(serverConfiguration));
+      }
+
+      return super.normalize(uri);
+   }
+
+   @Override
+   public Optional<URI> resolveModelURI(final Context ctx, final String key) {
+      APIVersion apiVersion = getAPIVersion(ctx);
+      return getModelURI(ctx.queryParamMap(), key)
+         .flatMap(uri -> makeAbsolute(apiVersion, uri));
+   }
+
+   @Override
+   public Optional<URI> resolveModelURI(final WsContext ctx, final String key) {
+      APIVersion apiVersion = getAPIVersion(ctx);
+      return getModelURI(ctx.queryParamMap(), key)
+         .flatMap(uri -> makeAbsolute(apiVersion, uri));
+   }
+
+   @Override
+   public URI deresolveModelURI(final Context ctx, final URI modelURI) {
+      return makeRelative(getAPIVersion(ctx), modelURI);
+   }
+
+   @Override
+   public URI deresolveModelURI(final WsContext ctx, final URI modelURI) {
+      return makeRelative(getAPIVersion(ctx), modelURI);
+   }
+
+   protected Optional<URI> getModelURI(final Map<String, List<String>> queryParameters, final String key) {
+      return Optional.of(queryParameters.getOrDefault(key, List.of()))
+         .filter(Predicate.not(List::isEmpty)).map(list -> list.get(0)).map(DefaultModelURIConverter::parseURI);
+   }
+
+   /**
+    * Parse an incoming URI string as an EMF URI without trying to resolve it.
+    * This handles the case of a Windows path string with a leading device.
+    *
+    * @param uri the incoming URI string
+    * @return the parsed URI
+    */
+   public static URI parseURI(final String uri) {
+      Matcher scheme = SCHEME_PATTERN.matcher(uri);
+      if (scheme.find() && scheme.group(1).length() == 1) {
+         // Looks like a Windows file path. Convert separators and remove any leading separators
+         // because the hierarchical URI will already include a slash after the device
+         List<String> filePath = Arrays.asList(uri.substring(scheme.end()).replace('\\', '/').split("/+"));
+
+         // Remove empty segments, especially leading segments because a device URI already includes the leading /
+         filePath = filePath.stream().filter(not(String::isEmpty)).collect(Collectors.toList());
+
+         // File URIs for the model URI must not include a query or a fragment, and certainly not an authority
+         return URI.createHierarchicalURI("file", null, scheme.group(0), filePath.toArray(String[]::new), null, null);
+      }
+
+      // It's either a relative or an absolute URI, but either way, it's not an absolute Windows file path.
+      // If there were legitimate backslashes that should have been within path segments, they should have
+      // been escaped, so this heuristic handles naïve Windows file URIs
+      return URI.createURI(uri.replace('\\', '/'));
+   }
+
+   /**
+    * Make an absolute URI from the given model URI query parameter.
+    *
+    * @param apiVersion the API version of the request or message context
+    * @param modelURI   a model URI from the client request query parameter
+    *
+    * @return the absolute URI, if validly computable from the query parameter
+    */
+   protected Optional<URI> makeAbsolute(final APIVersion apiVersion, final URI modelURI) {
+      return modelURIResolvers.getOrDefault(apiVersion, uri -> Optional.ofNullable(uri).filter(not(URI::isRelative)))
+         .apply(modelURI);
+   }
+
+   /**
+    * Make a relative URI from the given absolute model URI.
+    *
+    * @param apiVersion the API version of the request or message context
+    * @param modelURI   an absolute model URI resolved through this strategy
+    *
+    * @return the relative URI for return to the client
+    */
+   protected URI makeRelative(final APIVersion apiVersion, final URI modelURI) {
+      return modelURIDeresolvers.getOrDefault(apiVersion, identity()).apply(modelURI);
+   }
+
+   @Inject(optional = true)
+   protected void setModelURIResolvers(
+      @Named(MODEL_URI_RESOLVERS) final Map<APIVersionRange, Function<? super URI, Optional<URI>>> modelURIResolvers) {
+
+      this.modelURIResolvers.putAll(modelURIResolvers);
+   }
+
+   @Inject(optional = true)
+   protected void setModelURIDeresolvers(
+      @Named(MODEL_URI_DERESOLVERS) final Map<APIVersionRange, Function<? super URI, URI>> modelURIDeresolvers) {
+
+      this.modelURIDeresolvers.putAll(modelURIDeresolvers);
+   }
+
+   /**
+    * Get the workspace root URI as a directory URI, with a trailing slash.
+    *
+    * @return the workspace root directory URI
+    */
+   static URI getWorkspaceRootDirectoryURI(final ServerConfiguration serverConfig) {
+      URI result = serverConfig.getWorkspaceRootURI();
+      if (result != null && !result.hasTrailingPathSeparator()) {
+         result = result.appendSegment("");
+      }
+      return result;
+   }
+
+   //
+   // Nested types
+   //
+
+   /** Model URI parameter resolver for API V1. */
+   public static class APIV1Resolver implements Function<URI, Optional<URI>> {
+      protected final ModelResourceManager modelResourceManager;
+
+      @Inject
+      public APIV1Resolver(final ModelResourceManager modelResourceManager) {
+         super();
+
+         this.modelResourceManager = modelResourceManager;
+      }
+
+      @Override
+      public Optional<URI> apply(final URI modelURI) {
+         // Compatibility
+         @SuppressWarnings("deprecation")
+         String adaptedURI = modelResourceManager.adaptModelUri(modelURI.toString());
+         return Optional.ofNullable(adaptedURI).map(URI::createURI);
+      }
+   }
+
+   /** Model URI result deresolver for API V1. */
+   public static class APIV1Deresolver implements Function<URI, URI> {
+      @Override
+      public URI apply(final URI modelURI) {
+         // Compatibility
+         return modelURI;
+      }
+   }
+
+   /** Model URI parameter resolver for API V2. */
+   public static class APIV2Resolver implements Function<URI, Optional<URI>> {
+      protected final ServerConfiguration serverConfiguration;
+
+      @Named(MODEL_URI_VALIDATOR)
+      @Inject(optional = true)
+      protected Predicate<? super URI> modelURIValidator = URI::isRelative;
+
+      @Inject
+      public APIV2Resolver(final ServerConfiguration serverConfiguration) {
+         super();
+
+         this.serverConfiguration = serverConfiguration;
+      }
+
+      @Override
+      public Optional<URI> apply(final URI modelURI) {
+         return Optional.ofNullable(modelURI).filter(modelURIValidator)
+            .map(uri -> uri.resolve(getWorkspaceRootDirectoryURI(serverConfiguration)));
+      }
+   }
+
+   /** Model URI result deresolver for API V2. */
+   public static class APIV2Deresolver implements Function<URI, URI> {
+      protected final ServerConfiguration serverConfiguration;
+
+      @Inject
+      public APIV2Deresolver(final ServerConfiguration serverConfiguration) {
+         super();
+
+         this.serverConfiguration = serverConfiguration;
+      }
+
+      @Override
+      public URI apply(final URI modelURI) {
+         if (modelURI.isRelative()) {
+            return modelURI;
+         }
+
+         return modelURI.deresolve(getWorkspaceRootDirectoryURI(serverConfiguration));
+      }
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultResourceSetFactory.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultResourceSetFactory.java
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import javax.inject.Inject;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.URIConverter;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+
+public class DefaultResourceSetFactory implements ResourceSetFactory {
+
+   protected URIConverter uriConverter;
+
+   public DefaultResourceSetFactory() {
+      super();
+   }
+
+   @Inject
+   public void setURIConverter(final URIConverter uriConverter) { this.uriConverter = uriConverter; }
+
+   @Override
+   public ResourceSet createResourceSet(final URI modelURI) {
+      ResourceSet result = new ResourceSetImpl();
+
+      result.setURIConverter(uriConverter);
+
+      return result;
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelRepository.java
@@ -31,6 +31,10 @@ public interface ModelRepository {
 
    Optional<Resource> loadResource(String modeluri);
 
+   /**
+    * @deprecated deresolution of model URIs is the responsibility of the {@link ModelURIConverter} service
+    */
+   @Deprecated
    Set<String> getRelativeModelUris();
 
    Set<String> getAbsoluteModelUris();

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelResourceManager.java
@@ -91,7 +91,11 @@ public interface ModelResourceManager {
     *
     * @param modelUri the client-supplied model URI
     * @return the adapted URI ready to be consumed
+    *
+    * @deprecated Resolution/normalization/etc. of incoming model URIs is the responsibility of the
+    *             {@link ModelURIConverter} service
     */
+   @Deprecated
    default String adaptModelUri(final String modelUri) {
       URI uri = URI.createURI(modelUri, true);
       // we do not know the server configuration for relative URIs nor the possible schemes here...

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
@@ -42,6 +42,11 @@ public class ModelServerRoutingV1 implements Routing {
          serverController, sessionController, ModelServerPathsV1.BASE_PATH);
    }
 
+   @Inject
+   public void setModelURIConverter(final ModelURIConverter uriConverter) {
+      this.delegate.setModelURIConverter(uriConverter);
+   }
+
    @Override
    public void bindRoutes() {
       bindRoutes(this::endpoints);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV2.java
@@ -18,9 +18,7 @@ import static io.javalin.apibuilder.ApiBuilder.patch;
 import static io.javalin.apibuilder.ApiBuilder.post;
 import static io.javalin.apibuilder.ApiBuilder.put;
 import static io.javalin.apibuilder.ApiBuilder.ws;
-import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2.MODEL_URI;
 import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextResponse.error;
-import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextResponse.missingParameter;
 
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV2;
 import org.eclipse.emfcloud.modelserver.common.Routing;
@@ -46,7 +44,10 @@ public class ModelServerRoutingV2 implements Routing {
    protected final SessionController sessionController;
    protected final TransactionController transactionController;
 
+   protected ModelURIConverter uriConverter;
+
    @Inject
+   @SuppressWarnings("checkstyle:ParameterNumber")
    public ModelServerRoutingV2(final Javalin javalin, final ModelResourceManager resourceManager,
       final ModelController modelController, final SchemaController schemaController,
       final ServerController serverController, final SessionController sessionController,
@@ -61,6 +62,12 @@ public class ModelServerRoutingV2 implements Routing {
       this.modelController = modelController;
       this.sessionController = sessionController;
       this.transactionController = transactionController;
+   }
+
+   @Inject
+   public void setModelURIConverter(final ModelURIConverter uriConverter) {
+      this.uriConverter = uriConverter;
+      this.delegate.setModelURIConverter(uriConverter);
    }
 
    @Override
@@ -122,9 +129,7 @@ public class ModelServerRoutingV2 implements Routing {
    }
 
    protected void createTransaction(final Context ctx) {
-      delegate.getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
-         param -> transactionController.create(ctx, param),
-         () -> missingParameter(ctx, MODEL_URI));
+      uriConverter.withResolvedModelURI(ctx, modeluri -> transactionController.create(ctx, modeluri));
    }
 
    protected void openTransaction(final WsConfig wsConfig) {
@@ -135,8 +140,6 @@ public class ModelServerRoutingV2 implements Routing {
    }
 
    protected void executeCommand(final Context ctx) {
-      delegate.getResolvedFileUri(ctx, MODEL_URI).ifPresentOrElse(
-         param -> modelController.executeCommandV2(ctx, param),
-         () -> missingParameter(ctx, MODEL_URI));
+      uriConverter.withResolvedModelURI(ctx, modeluri -> modelController.executeCommandV2(ctx, modeluri));
    }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelURIConverter.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelURIConverter.java
@@ -1,0 +1,208 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2.MODEL_URI;
+import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextResponse.missingParameter;
+import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextResponse.modelNotFound;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.URIConverter;
+import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV2;
+
+import io.javalin.http.Context;
+import io.javalin.websocket.WsContext;
+
+/**
+ * A service that resolves the or URI indicated in incoming requests and messages.
+ * Request handlers should use this service also to deresolve model URIs if outgoing responses
+ * and messages, where such may make reference to model URIs that can be turned around by clients
+ * as parameters for subsequent resquests and responses. The most basic case of this being the
+ * handler for the {@link ModelServerPathsV2#MODEL_URIS /api/v2/modeluris} GET request.
+ */
+public interface ModelURIConverter extends URIConverter {
+
+   /**
+    * Resolve the model URI to which a request pertains to an absolute URI suitable for access to an EMF
+    * {@link ResourceSet}.
+    * The result is optional to allow for implementations to refuse to resolve <tt>modeluri</tt> parameters matching
+    * whatever
+    * validation criteria they may impose, e.g. disallowing simple file paths or absolute URIs.
+    *
+    * @param ctx the incoming request context
+    * @param key the request parameter key to look up to get the model URI
+    * @return the resolved absolute URI, if the request parameter is resolvable
+    */
+   Optional<URI> resolveModelURI(Context ctx, String key);
+
+   /**
+    * Resolve the model URI to which a message pertains to an absolute URI suitable for access to an EMF
+    * {@link ResourceSet}.
+    * The result is optional to allow for implementations to refuse to resolve <tt>modeluri</tt> parameters matching
+    * whatever
+    * validation criteria they may impose, e.g. disallowing simple file paths or absolute URIs.
+    *
+    * @param ctx the incoming message context
+    * @param key the message context parameter key to look up to get the model URI
+    * @return the resolved absolute URI, if the message context parameter is resolvable
+    */
+   Optional<URI> resolveModelURI(WsContext ctx, String key);
+
+   /**
+    * Apply a {@code processor} function to the resolved model URI in the request.
+    * If the model URI does not resolve, responds automatically with a 404.
+    *
+    * @param <T>       the processor result
+    * @param ctx       the request context
+    * @param key       the request parameter key to look up to get the model URI
+    * @param processor a function to process the resolved URI
+    *
+    * @return the result of the {@code processor}, or empty if 404
+    */
+   default <T> Optional<T> applyResolvedModelURI(final Context ctx, final String key,
+      final Function<? super String, T> processor) {
+
+      return this.resolveModelURI(ctx, key).map(URI::toString).map(processor).or(() -> {
+         respondMissingOrUnspecifiedModel(ctx, key);
+         return Optional.empty();
+      });
+   }
+
+   default void respondMissingOrUnspecifiedModel(final Context ctx, final String key) {
+      Optional.ofNullable(ctx.queryParam(key)).ifPresentOrElse(
+         modeluri -> modelNotFound(ctx, deresolveModelURI(ctx, modeluri)),
+         () -> missingParameter(ctx, key));
+   }
+
+   /**
+    * Apply a {@code processor} operation to the resolved model URI in the request.
+    * If the model URI does not resolve, responds automatically with a 404.
+    *
+    * @param ctx       the request context
+    * @param key       the request parameter key to look up to get the model URI
+    * @param processor an operation to process the resolved URI
+    */
+   default void withResolvedModelURI(final Context ctx, final String key, final Consumer<? super String> processor) {
+      this.resolveModelURI(ctx, key).map(URI::toString).ifPresentOrElse(processor,
+         () -> respondMissingOrUnspecifiedModel(ctx, key));
+   }
+
+   /**
+    * Resolve the model URI to which a request pertains to an absolute URI suitable for access to an EMF
+    * {@link ResourceSet}.
+    * The result is optional to allow for implementations to refuse to resolve <tt>modeluri</tt> parameters matching
+    * whatever
+    * validation criteria they may impose, e.g. disallowing simple file paths or absolute URIs.
+    *
+    * @param ctx the incoming request context
+    * @return the resolved absolute URI, if the request parameter is resolvable
+    */
+   default Optional<URI> resolveModelURI(final Context ctx) {
+      return resolveModelURI(ctx, MODEL_URI);
+   }
+
+   /**
+    * Resolve the model URI to which a message pertains to an absolute URI suitable for access to an EMF
+    * {@link ResourceSet}.
+    * The result is optional to allow for implementations to refuse to resolve <tt>modeluri</tt> parameters matching
+    * whatever
+    * validation criteria they may impose, e.g. disallowing simple file paths or absolute URIs.
+    *
+    * @param ctx the incoming message context
+    * @return the resolved absolute URI, if the message context parameter is resolvable
+    */
+   default Optional<URI> resolveModelURI(final WsContext ctx) {
+      return resolveModelURI(ctx, MODEL_URI);
+   }
+
+   /**
+    * Apply a {@code processor} function to the resolved model URI in the request.
+    * If the model URI does not resolve, responds automatically with a 404.
+    *
+    * @param <T>       the processor result
+    * @param ctx       the request context
+    * @param processor a function to process the resolved URI
+    *
+    * @return the result of the {@code processor}, or empty if 404
+    */
+   default <T> Optional<T> applyResolvedModelURI(final Context ctx, final Function<? super String, T> processor) {
+      return applyResolvedModelURI(ctx, MODEL_URI, processor);
+   }
+
+   /**
+    * Apply a {@code processor} operation to the resolved model URI in the request.
+    * If the model URI does not resolve, responds automatically with a 404.
+    *
+    * @param ctx       the request context
+    * @param processor an operation to process the resolved URI
+    */
+   default void withResolvedModelURI(final Context ctx, final Consumer<? super String> processor) {
+      withResolvedModelURI(ctx, MODEL_URI, processor);
+   }
+
+   /**
+    * Deresolve an absolute model URI for response to the given context request.
+    *
+    * @param ctx      the request context
+    * @param modelURI the absolute model URI to deresolve
+    *
+    * @return the deresolved URI
+    *
+    * @throws IllegalArgumentException if the given model URI is {@link URI#isRelative() not an absolute URI}
+    */
+   URI deresolveModelURI(Context ctx, URI modelURI);
+
+   /**
+    * Deresolve an absolute model URI for reply to the given incoming message context.
+    *
+    * @param ctx      the message context
+    * @param modelURI the absolute model URI to deresolve
+    *
+    * @return the deresolved URI
+    *
+    * @throws IllegalArgumentException if the given model URI is {@link URI#isRelative() not an absolute URI}
+    */
+   URI deresolveModelURI(WsContext ctx, URI modelURI);
+
+   /**
+    * Deresolve an absolute model URI for response to the given context request.
+    *
+    * @param ctx      the request context
+    * @param modelURI the absolute model URI to deresolve
+    *
+    * @return the deresolved URI
+    *
+    * @throws IllegalArgumentException if the given model URI is {@link URI#isRelative() not an absolute URI}
+    */
+   default String deresolveModelURI(final Context ctx, final String modelURI) {
+      return deresolveModelURI(ctx, URI.createURI(modelURI)).toString();
+   }
+
+   /**
+    * Deresolve an absolute model URI for reply to the given incoming message.
+    *
+    * @param ctx      the message context
+    * @param modelURI the absolute model URI to deresolve
+    *
+    * @return the deresolved URI
+    *
+    * @throws IllegalArgumentException if the given model URI is {@link URI#isRelative() not an absolute URI}
+    */
+   default String deresolveModelURI(final WsContext ctx, final String modelURI) {
+      return deresolveModelURI(ctx, URI.createURI(modelURI)).toString();
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ResourceSetFactory.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ResourceSetFactory.java
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
+/**
+ * A service that creates resource sets for management of model resources.
+ */
+public interface ResourceSetFactory {
+
+   ResourceSet createResourceSet(URI modelURI);
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/util/ContextRequest.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/util/ContextRequest.java
@@ -17,9 +17,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.emfcloud.modelserver.common.APIVersion;
 import org.eclipse.emfcloud.modelserver.emf.common.JsonResponseMember;
 import org.eclipse.emfcloud.modelserver.emf.di.ProviderDefaults;
 
@@ -32,6 +35,8 @@ import io.javalin.websocket.WsMessageContext;
 
 public final class ContextRequest {
    protected static final Logger LOG = LogManager.getLogger(ContextRequest.class.getSimpleName());
+
+   private static final Pattern API_PATTERN = Pattern.compile("^/?api/v(\\d+)\\b");
 
    private ContextRequest() {}
 
@@ -173,6 +178,19 @@ public final class ContextRequest {
          return Optional.empty();
       }
       return Optional.of(jsonType);
+   }
+
+   public static APIVersion getAPIVersion(final Context ctx) {
+      return getAPIVersion(ctx.matchedPath());
+   }
+
+   public static APIVersion getAPIVersion(final WsContext ctx) {
+      return getAPIVersion(ctx.matchedPath());
+   }
+
+   protected static APIVersion getAPIVersion(final String apiPath) {
+      Matcher m = API_PATTERN.matcher(apiPath);
+      return m.find() ? new APIVersion(Integer.parseInt(m.group(1))) : APIVersion.ZERO;
    }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ModelServerModule.java
@@ -14,20 +14,22 @@ import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.emfcloud.modelserver.common.di.AbstractModuleWithInitializers;
 import org.eclipse.emfcloud.modelserver.common.utils.MapBinding;
 import org.eclipse.emfcloud.modelserver.common.utils.MultiBinding;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.launch.ModelServerStartup;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 
-public abstract class ModelServerModule extends AbstractModule {
+public abstract class ModelServerModule extends AbstractModuleWithInitializers {
 
    protected static final Logger LOG = LogManager.getLogger(ModelServerModule.class);
 
    @Override
    protected void configure() {
+      super.configure();
+
       // minimal setup
       bind(ModelServerStartup.class).to(bindModelServerStartup()).in(Singleton.class);
       bind(ServerConfiguration.class).to(bindServerConfiguration()).in(Singleton.class);

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/MultiBindingDefaults.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/MultiBindingDefaults.java
@@ -12,7 +12,12 @@ package org.eclipse.emfcloud.modelserver.emf.di;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emfcloud.modelserver.common.APIVersion;
+import org.eclipse.emfcloud.modelserver.common.APIVersionRange;
 import org.eclipse.emfcloud.modelserver.common.AppEntryPoint;
 import org.eclipse.emfcloud.modelserver.common.EntryPointType;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
@@ -27,6 +32,7 @@ import org.eclipse.emfcloud.modelserver.edit.command.CompoundCommandContribution
 import org.eclipse.emfcloud.modelserver.edit.command.RemoveCommandContribution;
 import org.eclipse.emfcloud.modelserver.edit.command.SetCommandContribution;
 import org.eclipse.emfcloud.modelserver.edit.command.UpdateModelCommandContribution;
+import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelServerRoutingV1;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelServerRoutingV2;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodec;
@@ -66,4 +72,15 @@ public final class MultiBindingDefaults {
 
    public static final List<Class<? extends ModelWatcher.Factory>> DEFAULT_MODEL_WATCHER_FACTORIES = List.of(
       FileModelWatcher.Factory.class);
+
+   public static final Map<APIVersionRange, Class<? extends Function<? super URI, Optional<URI>>>> DEFAULT_MODEL_URI_RESOLVERS = Map
+      .of(
+         APIVersion.ZERO.range(APIVersion.of(2)), DefaultModelURIConverter.APIV1Resolver.class,
+         APIVersion.of(2).range(), DefaultModelURIConverter.APIV2Resolver.class);
+
+   public static final Map<APIVersionRange, Class<? extends Function<? super URI, URI>>> DEFAULT_MODEL_URI_DERESOLVERS = Map
+      .of(
+         APIVersion.ZERO.range(APIVersion.of(2)), DefaultModelURIConverter.APIV1Deresolver.class,
+         APIVersion.of(2).range(), DefaultModelURIConverter.APIV2Deresolver.class);
+
 }

--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/client/ExampleModelServerClient.java
@@ -209,7 +209,7 @@ public final class ExampleModelServerClient {
       System.out.println("- " + CMD_SUBSCRIBE + " <modelUri> <format>");
       System.out.println("- " + CMD_UNSUBSCRIBE + " <modelUri>");
       System.out.println("- " + CMD_GET + " <modelUri>");
-      System.out.println("- " + CMD_GET_ALL + "<format>");
+      System.out.println("- " + CMD_GET_ALL + " <format>");
       System.out.println("- " + CMD_UPDATE_TASKS + " <name> // adapts all task names in SuperBrewer3000.json (custom)");
       System.out.println("- " + CMD_UNDO + " <modelUri>");
       System.out.println("- " + CMD_REDO + " <modelUri>");

--- a/tests/org.eclipse.emfcloud.modelserver.common.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.emfcloud.modelserver.common.tests/META-INF/MANIFEST.MF
@@ -10,6 +10,11 @@ Require-Bundle: com.fasterxml.jackson.core.jackson-annotations;bundle-version="[
  com.fasterxml.jackson.core.jackson-databind;bundle-version="[2.9.0,3.0.0)",
  org.eclipse.emf.ecore;bundle-version="[2.20.0,3.0.0)",
  org.eclipse.emfcloud.modelserver.tests;bundle-version="[0.7.0,1.0.0)",
- org.junit;bundle-version="[4.12.0,5.0.0)"
-Export-Package: org.eclipse.emfcloud.modelserver.common.tests.jsonschema
+ org.junit;bundle-version="[4.12.0,5.0.0)",
+ com.google.guava;bundle-version="[30.1.0,31.0.0)",
+ org.aopalliance;bundle-version="[1.0.0,2.0.0)"
+Export-Package: org.eclipse.emfcloud.modelserver.common.tests.di,
+ org.eclipse.emfcloud.modelserver.common.tests.jsonschema,
+ org.eclipse.emfcloud.modelserver.common.tests.utils
 Bundle-Vendor: EclipseSource
+Import-Package: javax.inject;version="[1.0.0,2.0.0)"

--- a/tests/org.eclipse.emfcloud.modelserver.common.tests/src/org/eclipse/emfcloud/modelserver/common/tests/di/AbstractModuleWithInitializersTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.common.tests/src/org/eclipse/emfcloud/modelserver/common/tests/di/AbstractModuleWithInitializersTest.java
@@ -1,0 +1,132 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common.tests.di;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+import javax.inject.Inject;
+
+import org.eclipse.emfcloud.modelserver.common.di.AbstractModuleWithInitializers;
+import org.eclipse.emfcloud.modelserver.common.di.Initialize;
+import org.junit.Test;
+
+import com.google.inject.Guice;
+import com.google.inject.Module;
+import com.google.inject.ProvisionException;
+
+public class AbstractModuleWithInitializersTest {
+
+   public AbstractModuleWithInitializersTest() {
+      super();
+   }
+
+   @Test
+   public void basicInitializer() {
+      inject(InitializeMe.class).verify();
+   }
+
+   @Test
+   public void inheritedInitializer() {
+      inject(SubInitializeMe.class).verify();
+   }
+
+   @Test
+   public void overriddenInitializer() {
+      inject(OverrideMe.class).verify();
+   }
+
+   @Test
+   public void inheritedInitializerNotReannotated() {
+      inject(OverrideMe2.class).verify();
+   }
+
+   @Test(expected = ProvisionException.class)
+   public void tooManyInitializers() {
+      inject(Bomb.class);
+   }
+
+   //
+   // Test framework
+   //
+
+   InjectMe inject(final Class<? extends InjectMe> binding) {
+      Module module = new AbstractModuleWithInitializers() {
+         @Override
+         protected void configure() {
+            super.configure();
+
+            bind(InjectMe.class).to(binding);
+         }
+      };
+
+      return Guice.createInjector(module).getInstance(InjectMe.class);
+   }
+
+   //
+   // Test classes
+   //
+
+   public static final class Dependency {
+      // Empty
+   }
+
+   public interface InjectMe {
+      void verify();
+   }
+
+   public static class InitializeMe implements InjectMe {
+      @Inject
+      private Dependency dependency;
+
+      private boolean initialized;
+
+      @Initialize
+      void init() {
+         assertThat("Dependency not injected yet", dependency, notNullValue());
+         initialized = true;
+      }
+
+      @Override
+      public void verify() {
+         assertThat("Not initialized by Guice", initialized, is(true));
+      }
+   }
+
+   public static class SubInitializeMe extends InitializeMe {
+      // Empty
+   }
+
+   public static class OverrideMe extends InitializeMe {
+      @Override
+      @Initialize
+      void init() {
+         super.init();
+      }
+   }
+
+   public static class OverrideMe2 extends OverrideMe {
+      @Override
+      void init() {
+         super.init();
+      }
+   }
+
+   public static class Bomb extends InitializeMe {
+      @Initialize
+      void tooManyInitializers() {
+         fail("Should not be called");
+      }
+   }
+
+}

--- a/tests/org.eclipse.emfcloud.modelserver.common.tests/src/org/eclipse/emfcloud/modelserver/common/tests/utils/APIVersionMapTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.common.tests/src/org/eclipse/emfcloud/modelserver/common/tests/utils/APIVersionMapTest.java
@@ -1,0 +1,64 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common.tests.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.emfcloud.modelserver.common.APIVersion;
+import org.eclipse.emfcloud.modelserver.common.utils.APIVersionMap;
+import org.junit.Test;
+
+@SuppressWarnings("checkstyle:MemberName")
+public class APIVersionMapTest {
+
+   private final APIVersion v1 = APIVersion.of(1);
+   private final APIVersion v1_0_1 = APIVersion.of(1, 0, 1);
+   private final APIVersion v1_1 = APIVersion.of(1, 1);
+   private final APIVersion v2 = APIVersion.of(2);
+   private final APIVersion v2_0_2 = APIVersion.of(2, 0, 2);
+   private final APIVersion v2_1 = APIVersion.of(2, 1);
+
+   public APIVersionMapTest() {
+      super();
+   }
+
+   @Test
+   public void get_nonOverlapping() {
+      APIVersionMap<String> map = new APIVersionMap<>();
+
+      map.put(v1.range(v2), "b");
+      map.put(v2.range(), "c");
+      map.put(APIVersion.ZERO.range(v1), "a");
+
+      assertThat(map.get(v1_0_1), is("b"));
+      assertThat(map.get(v2_1), is("c"));
+      assertThat(map.get(APIVersion.of(0, 5)), is("a"));
+   }
+
+   @Test
+   public void get_overlapping() {
+      APIVersionMap<String> map = new APIVersionMap<>();
+
+      map.put(v1_1.rangeInclusive(v2_1), "b");
+      map.put(v1.range(v2), "c");
+      map.put(APIVersion.ZERO.range(), "a");
+
+      assertThat(map.get(v1), is("c"));
+      assertThat(map.get(v1_0_1), is("c"));
+      assertThat(map.get(v1_1), is("b"));
+      assertThat(map.get(v2_1), is("b"));
+      assertThat(map.get(v2_0_2), is("b"));
+      assertThat(map.get(APIVersion.of(0, 5)), is("a"));
+      assertThat(map.get(APIVersion.of(2, 1, 1)), is("a"));
+   }
+
+}

--- a/tests/org.eclipse.emfcloud.modelserver.common.tests/src/org/eclipse/emfcloud/modelserver/common/tests/utils/APIVersionRangeTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.common.tests/src/org/eclipse/emfcloud/modelserver/common/tests/utils/APIVersionRangeTest.java
@@ -1,0 +1,108 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.common.tests.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.emfcloud.modelserver.common.APIVersion;
+import org.eclipse.emfcloud.modelserver.common.APIVersionRange;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Test;
+
+@SuppressWarnings("checkstyle:MemberName")
+public class APIVersionRangeTest {
+
+   private final APIVersion v1 = APIVersion.of(1);
+   private final APIVersion v1_0_1 = APIVersion.of(1, 0, 1);
+   private final APIVersion v1_1 = APIVersion.of(1, 1);
+   private final APIVersion v2_0_2 = APIVersion.of(2, 0, 2);
+   private final APIVersion v2_1 = APIVersion.of(2, 1);
+
+   public APIVersionRangeTest() {
+      super();
+   }
+
+   @Test
+   public void equals() {
+      assertThat(v1.range(), is(v1.range()));
+      assertThat(v1.range(v2_1), is(v1.range(v2_1)));
+      assertThat(v1.range(v2_1), not(v1.rangeInclusive(v2_1)));
+      assertThat(v1.range(v2_1), not(new APIVersionRange(v1, true, v2_1, true)));
+   }
+
+   @Test
+   public void includes() {
+      assertThat(v1.range(), includes(v2_1));
+      assertThat(v1.range(v2_1), includes(v2_0_2));
+      assertThat(v1.range(v2_1), not(includes(v2_1)));
+      assertThat(v1.rangeInclusive(v2_1), includes(v2_1));
+
+      assertThat(v1_0_1.range(v2_1), includes(v1_0_1));
+      assertThat(v1_0_1.range(v2_1), not(includes(v1)));
+      assertThat(new APIVersionRange(v1_0_1, true, v2_1, true), not(includes(v1_0_1)));
+   }
+
+   @Test
+   public void ordering() {
+      assertThat(v1.range(), orderedBefore(v1_0_1.range()));
+      // Closed lower bound before open lower bound
+      assertThat(v1.range(), orderedBefore(new APIVersionRange(v1, true)));
+      // Open upper bound before closed upper bound
+      assertThat(v1.range(v2_1), orderedBefore(v1.rangeInclusive(v2_1)));
+      // Lower bound is more significant than upper bound
+      assertThat(v1.range(v2_1), orderedBefore(v1_0_1.range(v1_1)));
+   }
+
+   //
+   // Test framework
+   //
+
+   Matcher<APIVersionRange> includes(final APIVersion version) {
+      return new TypeSafeDiagnosingMatcher<APIVersionRange>(APIVersionRange.class) {
+         @Override
+         protected boolean matchesSafely(final APIVersionRange item, final Description mismatchDescription) {
+            boolean result = item.includes(version);
+            if (!result) {
+               mismatchDescription.appendText("does not include version " + version);
+            }
+            return result;
+         }
+
+         @Override
+         public void describeTo(final Description description) {
+            description.appendText("includes version " + version);
+         }
+      };
+   }
+
+   Matcher<APIVersionRange> orderedBefore(final APIVersionRange range) {
+      return new TypeSafeDiagnosingMatcher<APIVersionRange>(APIVersionRange.class) {
+         @Override
+         protected boolean matchesSafely(final APIVersionRange item, final Description mismatchDescription) {
+            boolean result = item.compareTo(range) < 0;
+            if (!result) {
+               mismatchDescription.appendText("does not order before range " + range);
+            }
+            return result;
+         }
+
+         @Override
+         public void describeTo(final Description description) {
+            description.appendText("is ordered before range " + range);
+         }
+      };
+   }
+
+}

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/DefaultModelResourceManagerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/DefaultModelResourceManagerTest.java
@@ -33,16 +33,21 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.URIConverter;
 import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
+import org.eclipse.emfcloud.modelserver.common.di.AbstractModuleWithInitializers;
 import org.eclipse.emfcloud.modelserver.common.patch.JsonPatchException;
 import org.eclipse.emfcloud.modelserver.common.patch.JsonPatchTestException;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.DefaultResourceSetFactory;
+import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.ResourceSetFactory;
 import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatchersManager;
 import org.eclipse.emfcloud.modelserver.emf.configuration.CommandPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
@@ -59,9 +64,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Lists;
-import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -89,13 +94,15 @@ public class DefaultModelResourceManagerTest extends AbstractResourceTest {
    public void beforeTests() throws DecodingException {
       when(serverConfig.getWorkspaceRootURI())
          .thenReturn(URI.createFileURI(getCWD().getAbsolutePath() + "/" + RESOURCE_PATH));
-      modelResourceManager = Guice.createInjector(new AbstractModule() {
+      modelResourceManager = Guice.createInjector(new AbstractModuleWithInitializers() {
 
          private Multibinder<EPackageConfiguration> ePackageConfigurationBinder;
          private ArrayList<Class<? extends EPackageConfiguration>> ePackageConfigurations;
 
          @Override
          protected void configure() {
+            super.configure();
+
             ePackageConfigurations = Lists.newArrayList(
                EcorePackageConfiguration.class,
                CommandPackageConfiguration.class);
@@ -109,6 +116,8 @@ public class DefaultModelResourceManagerTest extends AbstractResourceTest {
             bind(ModelRepository.class).to(DefaultModelRepository.class).in(Scopes.SINGLETON);
             bind(ModelResourceManager.class).to(DefaultModelResourceManager.class).in(Scopes.SINGLETON);
             bind(JsonPatchHelper.class).toInstance(jsonPatchHelper);
+            bind(ResourceSetFactory.class).to(DefaultResourceSetFactory.class).in(Scopes.SINGLETON);
+            bind(URIConverter.class).to(DefaultModelURIConverter.class).in(Singleton.class);
          }
       }).getInstance(DefaultModelResourceManager.class);
    }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
@@ -107,6 +107,8 @@ public class DefaultModelControllerTest {
    @Mock
    private ServerConfiguration serverConfiguration;
    @Mock
+   private ModelURIConverter uriConverter;
+   @Mock
    private JsonPatchHelper jsonPatchHelper;
    @InjectMocks
    private DefaultModelValidator modelValidator;
@@ -130,7 +132,7 @@ public class DefaultModelControllerTest {
       modelValidator = new DefaultModelValidator(modelRepository, new DefaultFacetConfig(),
          EMFModule::setupDefaultMapper);
       modelController = new DefaultModelController(modelRepository, sessionController, serverConfiguration, codecs,
-         modelValidator, new PatchCommandHandler.RegistryImpl(), modelResourceManager, jsonPatchHelper);
+         modelValidator, new PatchCommandHandler.RegistryImpl(), modelResourceManager, uriConverter, jsonPatchHelper);
    }
 
    @Test
@@ -169,6 +171,8 @@ public class DefaultModelControllerTest {
       final Map<URI, EObject> allModels = Collections.singletonMap(URI.createURI("test"), brewingUnit);
       when(modelRepository.getAllModels()).thenReturn(allModels);
 
+      when(uriConverter.deresolveModelURI(any(Context.class), any(URI.class)))
+         .thenAnswer(invocation -> invocation.getArgument(1));
       modelController.getAll(context);
 
       assertThat(response.get().get(JsonResponseMember.DATA), is(equalTo(

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelRepositoryTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelRepositoryTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -72,6 +72,7 @@ public class DefaultModelRepositoryTest extends AbstractResourceTest {
       resultMap.keySet().equals(expectedModelUriSet);
    }
 
+   @SuppressWarnings("deprecation")
    @Test
    public void getAllModelUris() throws DecodingException, IOException {
       Set<String> expectedModelUriSet = new HashSet<>();

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelURIConverterTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelURIConverterTest.java
@@ -1,0 +1,343 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emfcloud.modelserver.common.APIVersion;
+import org.eclipse.emfcloud.modelserver.common.APIVersionRange;
+import org.eclipse.emfcloud.modelserver.common.utils.MapBinding;
+import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+
+import io.javalin.http.Context;
+import io.javalin.websocket.WsContext;
+
+@RunWith(Enclosed.class)
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class DefaultModelURIConverterTest {
+
+   // Note the Windows file URIs
+   static final URI WORKSPACE_ROOT_URI = URI.createURI("file:/C:/Users/junit/workspace");
+   static final String WORKSPACE_ROOT_PATH = "C:\\Users\\junit\\workspace\\";
+   static final URI OUTSIDE_WORKSPACE_DIRECTORY_URI = URI.createURI("file:/C:/Users/someoneelse/test/place");
+   static final String OUTSIDE_WORKSPACE_DIRECTORY_PATH = "C:\\Users\\someoneelse\\test\\place\\";
+
+   @Mock
+   ServerConfiguration serverConfiguration;
+
+   @Mock
+   ModelResourceManager resourceManager;
+
+   @Mock
+   Context requestCtx;
+
+   @Mock
+   WsContext socketCtx;
+
+   DefaultModelURIConverter uriConverter;
+
+   private final APIVersion apiVersion;
+
+   DefaultModelURIConverterTest(final APIVersion apiVersion) {
+      super();
+
+      this.apiVersion = apiVersion;
+   }
+
+   @RunWith(MockitoJUnitRunner.class)
+   public static class ApiV2 extends DefaultModelURIConverterTest {
+
+      public ApiV2() {
+         super(APIVersion.of(2));
+      }
+
+      @Test
+      public void testNormalizeURI() {
+         URI outsideWorkspaceAbsolute = outsideWorkspace("model.xmi");
+         URI uri = uriConverter.normalize(outsideWorkspaceAbsolute);
+         assertThat(uri, is(outsideWorkspaceAbsolute));
+
+         URI insideWorkspaceAbsolute = inWorkspace("model.xmi");
+         uri = uriConverter.normalize(insideWorkspaceAbsolute);
+         assertThat(uri, is(insideWorkspaceAbsolute));
+
+         URI relative = URI.createURI("nested/model.xmi");
+         URI expected = inWorkspace("nested", "model.xmi");
+         uri = uriConverter.normalize(relative);
+         assertThat(uri, is(expected));
+      }
+
+      @Test
+      public void resolveModelURI_Context() {
+         configureContexts();
+         Optional<URI> uri = uriConverter.resolveModelURI(requestCtx);
+         URI expected = inWorkspace("nested", "model.xmi");
+         assertThat("Relative path not resolved in the workspace", uri, is(Optional.of(expected)));
+
+         configureContexts(outsideWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(requestCtx);
+         assertThat("Absolute path outside the workspace not rejected", uri, is(Optional.empty()));
+
+         configureContexts(inWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(requestCtx);
+         assertThat("Absolute path inside the workspace not rejected", uri, is(Optional.empty()));
+      }
+
+      @Test
+      public void resolveModelURI_WsContext() {
+         configureContexts();
+         Optional<URI> uri = uriConverter.resolveModelURI(socketCtx);
+         URI expected = inWorkspace("nested", "model.xmi");
+         assertThat("Relative path not resolved in the workspace", uri, is(Optional.of(expected)));
+
+         configureContexts(outsideWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(socketCtx);
+         assertThat("Absolute path outside the workspace not rejected", uri, is(Optional.empty()));
+
+         configureContexts(inWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(socketCtx);
+         assertThat("Absolute path inside the workspace not rejected", uri, is(Optional.empty()));
+      }
+
+      @Test
+      public void testDeresolveModelURIContextURI() {
+         configureContexts();
+         URI uri = uriConverter.deresolveModelURI(requestCtx, inWorkspace("nested", "model.xmi"));
+         URI expected = URI.createURI("nested/model.xmi");
+         assertThat("URI in the workspace not deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(requestCtx, outsideWorkspace("nested", "model.xmi"));
+         // This is a weird consequence of deresolving URIs with Windows device parts
+         expected = URI.createURI("/Users/someoneelse/test/place/nested/model.xmi");
+         assertThat("URI outside the workspace not deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(requestCtx, URI.createURI("nested/model.xmi"));
+         expected = URI.createURI("nested/model.xmi");
+         assertThat("Relative URI modified by deresolution", uri, is(expected));
+      }
+
+      @Test
+      public void testDeresolveModelURIWsContextURI() {
+         configureContexts();
+         URI uri = uriConverter.deresolveModelURI(socketCtx, inWorkspace("nested", "model.xmi"));
+         URI expected = URI.createURI("nested/model.xmi");
+         assertThat("URI in the workspace not deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(socketCtx, outsideWorkspace("nested", "model.xmi"));
+         // This is a weird consequence of deresolving URIs with Windows device parts
+         expected = URI.createURI("/Users/someoneelse/test/place/nested/model.xmi");
+         assertThat("URI outside the workspace not deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(socketCtx, URI.createURI("nested/model.xmi"));
+         expected = URI.createURI("nested/model.xmi");
+         assertThat("Relative URI modified by deresolution", uri, is(expected));
+      }
+   }
+
+   @RunWith(MockitoJUnitRunner.class)
+   public static class ApiV1 extends DefaultModelURIConverterTest {
+
+      public ApiV1() {
+         super(APIVersion.of(1));
+      }
+
+      @Test
+      public void testNormalizeURI() {
+         URI outsideWorkspaceAbsolute = outsideWorkspace("model.xmi");
+         URI uri = uriConverter.normalize(outsideWorkspaceAbsolute);
+         assertThat(uri, is(outsideWorkspaceAbsolute));
+
+         URI insideWorkspaceAbsolute = inWorkspace("model.xmi");
+         uri = uriConverter.normalize(insideWorkspaceAbsolute);
+         assertThat(uri, is(insideWorkspaceAbsolute));
+
+         URI relative = URI.createURI("nested/model.xmi");
+         URI expected = inWorkspace("nested", "model.xmi");
+         uri = uriConverter.normalize(relative);
+         assertThat(uri, is(expected));
+      }
+
+      @Test
+      public void resolveModelURI_Context() {
+         configureContexts();
+         Optional<URI> uri = uriConverter.resolveModelURI(requestCtx);
+         URI expected = inWorkspace("nested", "model.xmi");
+         assertThat("Relative path not resolved in the workspace", uri, is(Optional.of(expected)));
+
+         configureContexts(outsideWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(requestCtx);
+         expected = outsideWorkspace("nested", "model.xmi");
+         assertThat("Absolute path outside the workspace was rejected", uri, is(Optional.of(expected)));
+
+         configureContexts(inWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(requestCtx);
+         expected = inWorkspace("nested", "model.xmi");
+         assertThat("Absolute path inside the workspace was rejected", uri, is(Optional.of(expected)));
+      }
+
+      @Test
+      public void resolveModelURI_WsContext() {
+         configureContexts();
+         Optional<URI> uri = uriConverter.resolveModelURI(socketCtx);
+         URI expected = inWorkspace("nested", "model.xmi");
+         assertThat("Relative path not resolved in the workspace", uri, is(Optional.of(expected)));
+
+         configureContexts(outsideWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(socketCtx);
+         expected = outsideWorkspace("nested", "model.xmi");
+         assertThat("Absolute path outside the workspace was rejected", uri, is(Optional.of(expected)));
+
+         configureContexts(inWorkspacePath("nested", "model.xmi"));
+         uri = uriConverter.resolveModelURI(socketCtx);
+         expected = inWorkspace("nested", "model.xmi");
+         assertThat("Absolute path inside the workspace was rejected", uri, is(Optional.of(expected)));
+      }
+
+      @Test
+      public void testDeresolveModelURIContextURI() {
+         configureContexts();
+         URI uri = uriConverter.deresolveModelURI(requestCtx, inWorkspace("nested", "model.xmi"));
+         URI expected = inWorkspace("nested", "model.xmi");
+         assertThat("URI in the workspace was deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(requestCtx, outsideWorkspace("nested", "model.xmi"));
+         expected = outsideWorkspace("nested", "model.xmi");
+         assertThat("URI outside the workspace was deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(requestCtx, URI.createURI("nested/model.xmi"));
+         expected = URI.createURI("nested/model.xmi");
+         assertThat("Relative URI modified by deresolution", uri, is(expected));
+      }
+
+      @Test
+      public void testDeresolveModelURIWsContextURI() {
+         configureContexts();
+         URI uri = uriConverter.deresolveModelURI(socketCtx, inWorkspace("nested", "model.xmi"));
+         URI expected = inWorkspace("nested", "model.xmi");
+         assertThat("URI in the workspace was deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(socketCtx, outsideWorkspace("nested", "model.xmi"));
+         expected = outsideWorkspace("nested", "model.xmi");
+         assertThat("URI outside the workspace was deresolved", uri, is(expected));
+
+         uri = uriConverter.deresolveModelURI(socketCtx, URI.createURI("nested/model.xmi"));
+         expected = URI.createURI("nested/model.xmi");
+         assertThat("Relative URI modified by deresolution", uri, is(expected));
+      }
+   }
+
+   //
+   // Test framework
+   //
+
+   @Before
+   public void createTestFixture() {
+      @SuppressWarnings({ "deprecation", "checkstyle:AnonInnerLength" })
+      Module testModule = new AbstractModule() {
+         @Override
+         protected void configure() {
+            when(serverConfiguration.getWorkspaceRootURI()).thenReturn(WORKSPACE_ROOT_URI.appendSegment(""));
+            binder().bind(ServerConfiguration.class).toInstance(serverConfiguration);
+
+            // This is only needed for API v1 implementation
+            if (apiVersion.major() < 2) {
+               final DefaultModelResourceManager delegate = new DefaultModelResourceManager(Set.of(), null,
+                  serverConfiguration, null, null);
+               when(resourceManager.adaptModelUri(ArgumentMatchers.any(String.class))).then(invocation -> {
+                  String modelUri = invocation.getArgument(0);
+                  return delegate.adaptModelUri(modelUri);
+               });
+            }
+            binder().bind(ModelResourceManager.class).toInstance(resourceManager);
+
+            APIVersion two = APIVersion.of(2);
+            MapBinding<APIVersionRange, Function<? super URI, Optional<URI>>> resolverBindings = MapBinding
+               .create(APIVersionRange.class, new TypeLiteral<Function<? super URI, Optional<URI>>>() {});
+            resolverBindings.put(two.range(), DefaultModelURIConverter.APIV2Resolver.class);
+            resolverBindings.put(APIVersion.ZERO.range(two), DefaultModelURIConverter.APIV1Resolver.class);
+            resolverBindings.setAnnotationName(DefaultModelURIConverter.MODEL_URI_RESOLVERS);
+            resolverBindings.applyBinding(binder());
+
+            MapBinding<APIVersionRange, Function<? super URI, URI>> deresolverBindings = MapBinding.create(
+               APIVersionRange.class,
+               new TypeLiteral<Function<? super URI, URI>>() {});
+            deresolverBindings.put(two.range(), DefaultModelURIConverter.APIV2Deresolver.class);
+            deresolverBindings.put(APIVersion.ZERO.range(two), DefaultModelURIConverter.APIV1Deresolver.class);
+            deresolverBindings.setAnnotationName(DefaultModelURIConverter.MODEL_URI_DERESOLVERS);
+            deresolverBindings.applyBinding(binder());
+
+         }
+      };
+
+      this.uriConverter = Guice.createInjector(testModule).getInstance(DefaultModelURIConverter.class);
+   }
+
+   void configureContexts() {
+      // Note the windows separator
+      configureContexts("nested\\model.xmi");
+   }
+
+   void configureContexts(final String filePath) {
+      String apiPath = String.format("/api/v%d/models", apiVersion.major());
+
+      when(requestCtx.matchedPath()).thenReturn(apiPath);
+      when(requestCtx.queryParamMap()).thenReturn(Map.of("modeluri", List.of(filePath)));
+
+      when(socketCtx.matchedPath()).thenReturn(apiPath);
+      when(socketCtx.queryParamMap()).thenReturn(Map.of("modeluri", List.of(filePath)));
+   }
+
+   URI inWorkspace(final String... segments) {
+      return WORKSPACE_ROOT_URI.appendSegments(segments);
+   }
+
+   URI outsideWorkspace(final String... segments) {
+      return OUTSIDE_WORKSPACE_DIRECTORY_URI.appendSegments(segments);
+   }
+
+   String inWorkspacePath(final String... segments) {
+      StringBuilder result = new StringBuilder(WORKSPACE_ROOT_PATH);
+      for (String seg : segments) {
+         result.append('\\').append(seg);
+      }
+      return result.toString();
+   }
+
+   String outsideWorkspacePath(final String... segments) {
+      StringBuilder result = new StringBuilder(OUTSIDE_WORKSPACE_DIRECTORY_PATH);
+      for (String seg : segments) {
+         result.append('\\').append(seg);
+      }
+      return result.toString();
+   }
+
+}


### PR DESCRIPTION
## For the V2 API

This PR introduces two new core services for the management of URIs: a `ModelURIConverter` and a `ResourceSetFactory`.

### ResourceSetFactory

The resource set factory service creates the resource set identified by a `modeluri` query parameter for management of that resource and its associated companion resources. The `DefaultModelResourceManager` delegates to this service to create its resource sets.

The main thing that this factory does is to configure the resource set it creates with the `ModelURIConverter` service as the resource set's URI converter. This ensures that loading of resources within the resource set, whether directly by request handlers or indirectly via proxy resolution, uses the same rules for normalizing URIs and, especially, resolving relative URIs against the workspace location.

Model servers that wish to customize the resource sets that they create can now bind a subclass of the `DefaultResourceSetFactory` instead of a custom model resource manager. The custom factory should extend the superclass behaviour with registration of resource factories or whatever else the particular server needs.

### ModelURIResolver

This service extends the EMF `URIResolver` interface with APIs for getting the target model URI (usually the `modeluri` query parameter) out of the request or socket context as an EMF `URI` that is resolved against workspace root location in the case of an incoming relative URI. The `DefaultModelURIResolver` class attempts to be quite flexible in parsing incoming model URIs that look like file paths, especially Windows paths and naïve URIs based on them, such as

- relative\to\workspace\model.xmi
- relative/to/workspace/model.xmi
- c:\path\to\workspace\model.xmi
- /c:/path/to/workspace/model.xmi
- file:/c:/path/to/workspace/model.xmi
- file:/c:\path\to\workspace\model.xmi

> _Hopefully this will provide the benefit of resolving some outstanding bugs on Windows platform. In testing on Windows, I was able to throw pretty much any kind of URI or file path at the server in the `modeluri` query parameter._

The `ModelURIResolver` also provides API for relativizing outgoing model URIs against the workspace root, for example for responses to the `GET` request on the `modeluris` endpoint. All endpoint handlers that work with model URIs either as inputs or as outputs should use this new service to resolve incoming URIs and deresolve outgoing URIs for consistency.

The `DefaultModelURIResolver` is configurable for different resolution and deresolution rules for different API versions. This is managed by injection of

- `Function<URI, Optional<URI>>` mapped to an `APIVersionRange` for resolution of URIs. The optional result allows URIs to be rejected. For example, the default binding for API v2 and above allows only relative URIs in the query parameter, which then are resolved against the workspace location
- `Function<URI, URI>` mapped to an `APIVersionRange` for deresolution of URIs, generating URIs relative to the workspace location for response to the client

These version-specific dependencies are managed by new classes `APIVersion`, `APIVersionRange`, and `APIVersionMap` which last allows to map objects by API version range to look up the entry most applicable to a given API version. The intent is that these can help with future API-specific functionality and API evolution to new versions.

New `configureModelURIResolvers(...)` and `configureModelURIDeresolvers(...)` hooks in the `DefaultModelServerModule` make it easy for subclasses to replace or add URI resolver and deresolver bindings for whatever API version ranges they need to customize.

The default injections of URI handling in the `DefaultModelURIResolver` for API v2:

- accept only relative URIs in the `modeluri` query parameter, which then are resolved against the workspace root. This can be overridden by clients by injecting a custom `Predicate<? super URI>` named `modelURIValidator`
- deresolve all outgoing absolute URIs against the workspace root to get relative URIs

## For the V1 API

The default injections of URI handling in the `DefaultModelURIResolver` for API v1:

- accept both absolute and relative URIs in the `modeluri` query parameter. Relative URIs, of course, are resolved against the workspace location
- leave outgoing absolute URIs as they are

For compatibility with existing server implementations, the v1 URI resolver delegates to the `adaptModelUri(String)` method of the `DefaultModelResourceManager` class. This method is now deprecated and is not used in API v2.

Essentially, deresolution is a no-op for API v1 as most endpoints in v1 return absolute URIs for everything. The exception is the `modeluris` endpoint, which is updated with a special case for v1 to explicitly deresolve the model URIs that it returns.

A goal of this refactoring is to leave the API v1 behaviour exactly as it was while making the handling of URIs in API v2 and beyond more consistent and by default enforcing wherever possible that URIs be relative to the workspace location so that clients need even be aware of what the workspace URI is.

## Other Tidbits

The new injections in existing services try to be API compatible as much as is practical, so that servers extending this framework will continue to function normally without changes. This is only really assured for cases where the services are obtained from the Guice injector which, in normal operation, is already assumed. Unit tests, however, that often do directly construct and configure these services will need be adapted to these changes because there are new required dependencies.

Another detail to note is that the `DefaultModelResourceManager` presented a particular challenge for compatibility. In particular, it has an `initialize()` method that subclasses were expected to override to perform initialization of the workspace, but this was called from the constructor.
Not only is that an anti-pattern that leads to invocation of methods on objects that have not yet run their subclass constructors, but it runs the initialization before field or method injection can occur. To solve this issue, this PR introduces an `@Initialize` annotation for a method that the Guice injector will call only after all dependencies are injected. This is analogous to `@PostConstruct` in Eclipse e4 or `@postContruct()` in inversify.js. The implementation of this is provided by a new `AbstractModuleWithInitializers` class that can be used to configure bindings that use this new `@Initialize` mechanism. Again a consequence for unit tests that do not use Guice to configure services is that initializer methods would need to be invoked explicitly.

Contributed on behalf of STMicroelectronics.