### PR TITLE
API V2: Open the SettingValue API

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/patch/AbstractJsonPatchHelper.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/patch/AbstractJsonPatchHelper.java
@@ -654,7 +654,7 @@ public abstract class AbstractJsonPatchHelper {
     * an optional Index for list items, or a referenced element (e.g.
     * an EObject to remove, in which case there will be no Feature or Index)
     */
-   public final class SettingValue {
+   public static class SettingValue {
 
       private final EObject eObject;
 


### PR DESCRIPTION
Make the JsonPatchHelper.SettingValue class static instead of final, so clients can extend it.

Contributed on behalf of STMicroelectronics

Fixes #180