### PR TITLE
#184 Improve backward API compability

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClient.java
@@ -11,16 +11,17 @@
 package org.eclipse.emfcloud.modelserver.client;
 
 import java.net.MalformedURLException;
-import java.util.Set;
+import java.util.Map;
 
 import org.eclipse.emfcloud.modelserver.client.v2.ModelServerClientV2;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 
 import okhttp3.OkHttpClient;
 
 public class ModelServerClient extends ModelServerClientV2 {
 
-   public static final Set<String> DEFAULT_SUPPORTED_FORMATS = ModelServerClientV2.SUPPORTED_FORMATS;
+   public static final Map<String, Codec> DEFAULT_SUPPORTED_FORMATS = ModelServerClientV2.SUPPORTED_FORMATS;
    public static final String PATCH = ModelServerClientV2.PATCH;
    public static final String POST = ModelServerClientV2.POST;
 
@@ -29,7 +30,7 @@ public class ModelServerClient extends ModelServerClientV2 {
       super(baseUrl, configurations);
    }
 
-   public ModelServerClient(final String baseUrl, final Set<String> supportedFormats,
+   public ModelServerClient(final String baseUrl, final Map<String, Codec> supportedFormats,
       final EPackageConfiguration... configurations)
       throws MalformedURLException {
 

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v1/ModelServerClientV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v1/ModelServerClientV1.java
@@ -12,7 +12,8 @@ package org.eclipse.emfcloud.modelserver.client.v1;
 
 import java.net.MalformedURLException;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;
@@ -27,24 +28,31 @@ import org.eclipse.emfcloud.modelserver.client.SubscriptionListener;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV1;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
+import org.eclipse.emfcloud.modelserver.common.codecs.DefaultJsonCodec;
+import org.eclipse.emfcloud.modelserver.common.codecs.XmiCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.JsonResponseMember;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.internal.client.ModelServerClientDelegate;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 
+import okhttp3.HttpUrl.Builder;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 
 public class ModelServerClientV1 implements ModelServerClientApiV1<EObject>, ModelServerPathsV1, AutoCloseable {
 
-   public static final Set<String> SUPPORTED_FORMATS = Set.of(ModelServerPathParametersV1.FORMAT_JSON,
-      ModelServerPathParametersV1.FORMAT_XMI);
+   public static final Map<String, Codec> SUPPORTED_FORMATS = Map.of(
+      ModelServerPathParametersV1.FORMAT_JSON, new DefaultJsonCodec(),
+      ModelServerPathParametersV1.FORMAT_XMI, new XmiCodec());
 
    protected static final Logger LOG = LogManager.getLogger(ModelServerClientV1.class);
 
-   protected final ModelServerClientDelegate delegate;
+   private final ModelServerClientDelegate delegate;
 
    public ModelServerClientV1(final String baseUrl, final EPackageConfiguration... configurations)
       throws MalformedURLException {
@@ -53,7 +61,7 @@ public class ModelServerClientV1 implements ModelServerClientApiV1<EObject>, Mod
          configurations));
    }
 
-   public ModelServerClientV1(final String baseUrl, final Set<String> supportedFormats,
+   public ModelServerClientV1(final String baseUrl, final Map<String, Codec> supportedFormats,
       final EPackageConfiguration... configurations)
       throws MalformedURLException {
 
@@ -298,6 +306,48 @@ public class ModelServerClientV1 implements ModelServerClientApiV1<EObject>, Mod
    @Override
    public CompletableFuture<Response<Boolean>> redo(final String modelUri) {
       return delegate.redo(modelUri);
+   }
+
+   protected String getBaseUrl() { return delegate.getBaseUrl(); }
+
+   protected String makeWsUrl(final String path) {
+      return delegate.makeWsUrl(path);
+   }
+
+   protected String makeUrl(final String path) {
+      return delegate.makeUrl(path);
+   }
+
+   protected Builder createHttpUrlBuilder(final String path) {
+      return delegate.createHttpUrlBuilder(path);
+   }
+
+   public String checkedFormat(final String format) {
+      return delegate.checkedFormat(format);
+   }
+
+   public boolean isSupportedFormat(final String format) {
+      return delegate.isSupportedFormat(format);
+   }
+
+   protected String encode(final EObject eObject) {
+      return delegate.encode(eObject);
+   }
+
+   protected Optional<EObject> decode(final String payload) {
+      return delegate.decode(payload);
+   }
+
+   protected CompletableFuture<Response<Boolean>> makeCallAndExpectSuccess(final Request request) {
+      return delegate.makeCallAndExpectSuccess(request);
+   }
+
+   protected CompletableFuture<Response<String>> makeCallAndGetDataBody(final Request request) {
+      return delegate.makeCallAndGetDataBody(request);
+   }
+
+   public WebSocket createWebSocket(final Request request, final WebSocketListener listener) {
+      return delegate.createWebSocket(request, listener);
    }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/internal/client/ModelServerClientDelegate.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/internal/client/ModelServerClientDelegate.java
@@ -37,6 +37,7 @@ import org.eclipse.emfcloud.modelserver.client.SubscriptionListener;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathsV1;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.DefaultJsonCodec;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
@@ -57,6 +58,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import okhttp3.Call;
@@ -93,17 +95,17 @@ public class ModelServerClientDelegate implements AutoCloseable {
    protected final Map<EditingContextImpl<?>, WebSocket> openEditingSockets = new LinkedHashMap<>();
    protected final EPackageConfiguration[] configurations;
 
-   private final Set<String> supportedFormats;
+   private final Map<String, Codec> supportedFormats;
 
    public ModelServerClientDelegate(final String baseUrl, final String defaultFormat,
-      final Iterable<String> supportedFormats, final EPackageConfiguration... configurations)
+      final Map<String, Codec> supportedFormats, final EPackageConfiguration... configurations)
       throws MalformedURLException {
 
       this(new OkHttpClient(), baseUrl, defaultFormat, supportedFormats, configurations);
    }
 
    public ModelServerClientDelegate(final OkHttpClient client, final String baseUrl, final String defaultFormat,
-      final Iterable<String> supportedFormats, final EPackageConfiguration... configurations)
+      final Map<String, Codec> supportedFormats, final EPackageConfiguration... configurations)
       throws MalformedURLException {
 
       super();
@@ -112,8 +114,24 @@ public class ModelServerClientDelegate implements AutoCloseable {
       this.baseUrl = new URL(baseUrl).toString();
       this.defaultFormat = defaultFormat;
       this.configurations = configurations;
-      this.supportedFormats = ImmutableSet.copyOf(supportedFormats);
+      this.supportedFormats = initFormats(supportedFormats);
+
       this.init();
+   }
+
+   private static ImmutableMap<String, Codec> initFormats(final Map<String, Codec> supportedFormats) {
+      ImmutableMap.Builder<String, Codec> result = ImmutableMap.builder();
+
+      // Support these at a minimum for backward compatibility
+      if (!supportedFormats.containsKey(ModelServerPathParametersV1.FORMAT_XMI)) {
+         result.put(ModelServerPathParametersV1.FORMAT_XMI, new XmiCodec());
+      }
+      if (!supportedFormats.containsKey(ModelServerPathParametersV1.FORMAT_JSON)) {
+         result.put(ModelServerPathParametersV1.FORMAT_JSON, new DefaultJsonCodec());
+      }
+
+      result.putAll(supportedFormats);
+      return result.build();
    }
 
    protected void init() {
@@ -400,7 +418,7 @@ public class ModelServerClientDelegate implements AutoCloseable {
     * @return true when supported.
     */
    public boolean isSupportedFormat(final String format) {
-      return supportedFormats.contains(format);
+      return supportedFormats.containsKey(format);
    }
 
    /**
@@ -734,11 +752,17 @@ public class ModelServerClientDelegate implements AutoCloseable {
    }
 
    public String encode(final EObject eObject, final String format) {
+      Codec codec = supportedFormats.get(format);
+      if (codec == null) {
+         throw new IllegalArgumentException("Unsupported format: " + format);
+      }
+
       try {
-         if (format.equals(ModelServerPathParametersV1.FORMAT_XMI)) {
-            return new XmiCodec().encode(eObject).asText();
+         JsonNode json = codec.encode(eObject);
+         if (json.isValueNode()) {
+            return json.asText();
          }
-         return new DefaultJsonCodec().encode(eObject).toString();
+         return json.toString();
       } catch (EncodingException e) {
          LOG.error("Encoding of " + eObject + " with " + format + " format failed");
          throw new RuntimeException(e);
@@ -750,11 +774,13 @@ public class ModelServerClientDelegate implements AutoCloseable {
    }
 
    public Optional<EObject> decode(final String payload, final String format) {
+      Codec codec = supportedFormats.get(format);
+      if (codec == null) {
+         throw new IllegalArgumentException("Unsupported format: " + format);
+      }
+
       try {
-         if (format.equals(ModelServerPathParametersV1.FORMAT_XMI)) {
-            return new XmiCodec().decode(payload);
-         }
-         return new DefaultJsonCodec().decode(payload);
+         return codec.decode(payload);
       } catch (DecodingException e) {
          LOG.error("Decoding of " + payload + " with " + format + " format failed");
       }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingDelegate.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingDelegate.java
@@ -43,7 +43,7 @@ import io.javalin.websocket.WsMessageContext;
 /**
  * Implementation of common routing for multiple API versions.
  */
-public class ModelServerRoutingDelegate {
+class ModelServerRoutingDelegate {
    protected static final Logger LOG = LogManager.getLogger(ModelServerRoutingDelegate.class);
 
    protected final Javalin javalin;

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV1.java
@@ -25,10 +25,11 @@ import org.eclipse.emfcloud.modelserver.common.Routing;
 import com.google.inject.Inject;
 
 import io.javalin.Javalin;
+import io.javalin.apibuilder.EndpointGroup;
 
 public class ModelServerRoutingV1 implements Routing {
 
-   protected final ModelServerRoutingDelegate delegate;
+   private final ModelServerRoutingDelegate delegate;
 
    @Inject
    public ModelServerRoutingV1(final Javalin javalin, final ModelResourceManager resourceManager,
@@ -43,7 +44,11 @@ public class ModelServerRoutingV1 implements Routing {
 
    @Override
    public void bindRoutes() {
-      delegate.bindRoutes(this::endpoints);
+      bindRoutes(this::endpoints);
+   }
+
+   protected void bindRoutes(final EndpointGroup endpointGroup) {
+      delegate.bindRoutes(endpointGroup);
    }
 
    private void endpoints() {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelServerRoutingV2.java
@@ -28,6 +28,7 @@ import org.eclipse.emfcloud.modelserver.common.Routing;
 import com.google.inject.Inject;
 
 import io.javalin.Javalin;
+import io.javalin.apibuilder.EndpointGroup;
 import io.javalin.http.Context;
 import io.javalin.websocket.WsConfig;
 import io.javalin.websocket.WsConnectContext;
@@ -39,7 +40,7 @@ public class ModelServerRoutingV2 implements Routing {
     */
    protected static final String TRANSACTION_ENDPOINT = "transaction";
 
-   protected final ModelServerRoutingDelegate delegate;
+   private final ModelServerRoutingDelegate delegate;
 
    protected final ModelController modelController;
    protected final SessionController sessionController;
@@ -64,7 +65,11 @@ public class ModelServerRoutingV2 implements Routing {
 
    @Override
    public void bindRoutes() {
-      delegate.bindRoutes(this::endpoints);
+      bindRoutes(this::endpoints);
+   }
+
+   protected void bindRoutes(final EndpointGroup endpointGroup) {
+      delegate.bindRoutes(endpointGroup);
    }
 
    private void endpoints() {


### PR DESCRIPTION
- include the codecs that implement the supported formats in the client API
- add protected delegation APIs in public client and routing classes for continuity of access to APIs that existing clients rely on

Contributed on behalf of STMicroelectronics.
