### PR TITLE
193: JsonPatchHelper should normalize URIs when using EMF-style paths

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelper.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelper.java
@@ -33,6 +33,7 @@ import org.eclipse.emfcloud.modelserver.common.patch.AbstractJsonPatchHelper;
 import org.eclipse.emfcloud.modelserver.common.patch.LazyCompoundCommand;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelServerEditingDomain;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodecV2;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 
@@ -50,14 +51,16 @@ public class JsonPatchHelper extends AbstractJsonPatchHelper {
    private final ServerConfiguration serverConfiguration;
    private final Map<String, Codec> codecs;
    private final Codec fallback = new JsonCodecV2();
+   private final ModelURIConverter modelURIConverter;
 
    @Inject
    public JsonPatchHelper(final ModelResourceManager modelManager, final ServerConfiguration serverConfiguration,
-      final Map<String, Codec> codecs) {
+      final Map<String, Codec> codecs, final ModelURIConverter modelURIConverter) {
 
       this.modelManager = modelManager;
       this.serverConfiguration = serverConfiguration;
       this.codecs = Map.copyOf(codecs);
+      this.modelURIConverter = modelURIConverter;
    }
 
    @Override
@@ -81,7 +84,7 @@ public class JsonPatchHelper extends AbstractJsonPatchHelper {
       // Currently, trying to access a resource from a different resourceSet will cause
       // a write transaction exception
       // Issue: https://github.com/eclipse-emfcloud/emfcloud-modelserver/issues/159
-      URI uri = resourceURI == null ? URI.createURI(modelURI) : resourceURI;
+      URI uri = modelURIConverter.normalize(resourceURI == null ? URI.createURI(modelURI) : resourceURI);
       if (uri.isRelative()) {
          uri = uri.resolve(serverConfiguration.getWorkspaceRootURI());
       }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/watchers/FileModelWatcherIntegrationTest.java
@@ -50,6 +50,7 @@ import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultResourceSetFactory;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.ResourceSetFactory;
 import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
@@ -151,8 +152,8 @@ public class FileModelWatcherIntegrationTest extends AbstractResourceTest {
             bind(ModelRepository.class).to(DefaultModelRepository.class).in(Singleton.class);
             bind(ModelResourceManager.class).to(DefaultModelResourceManager.class).in(Singleton.class);
             bind(ResourceSetFactory.class).to(DefaultResourceSetFactory.class).in(Singleton.class);
-            bind(URIConverter.class).to(DefaultModelURIConverter.class).in(Singleton.class);
-
+            bind(ModelURIConverter.class).to(DefaultModelURIConverter.class).in(Singleton.class);
+            bind(URIConverter.class).to(ModelURIConverter.class);
          }
       }
 


### PR DESCRIPTION
- Normalize URIs in ~DefaultModelResourceManager~ and JsonPatchHelper

Contributed on behalf of STMicroelectronics.

fixes #193 