### PR TITLE
API v2: Subscription option for URI fragments in update notifications

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/ModelServerClientApiV2.java
@@ -69,22 +69,118 @@ public interface ModelServerClientApiV2<A> {
 
    CompletableFuture<Response<String>> edit(String modelUri, ArrayNode jsonPatch, String format);
 
+   /**
+    * Subscribe to notifications from the server about the given model with default options and
+    * not including live validation results.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribe(String modelUri, SubscriptionListener subscriptionListener);
 
+   /**
+    * Subscribe to notifications from the server about the given model without live validation results,
+    * in the given message {@code format}.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    * @param format               the format in which to encode the subscription messages
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribe(String modelUri, SubscriptionListener subscriptionListener, String format);
 
+   /**
+    * Subscribe to notifications from the server about the given model without live validation results.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    * @param timeout              a timeout, in milleseconds, after which idle time to close the subscription
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribe(String modelUri, SubscriptionListener subscriptionListener, long timeout);
 
+   /**
+    * Subscribe to notifications from the server about the given model without live validation results,
+    * in the given message {@code format}.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    * @param format               the format in which to encode the subscription messages
+    * @param timeout              a timeout, in milleseconds, after which idle time to close the subscription
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribe(String modelUri, SubscriptionListener subscriptionListener, String format, long timeout);
 
+   /**
+    * Subscribe to notifications from the server about the given model, including live validation
+    * results, but otherwise with default options.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribeWithValidation(String modelUri, SubscriptionListener subscriptionListener);
 
+   /**
+    * Subscribe to notifications from the server about the given model, including live validation
+    * results, in the given message {@code format}.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    * @param format               the format in which to encode the subscription messages
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribeWithValidation(String modelUri, SubscriptionListener subscriptionListener, String format);
 
+   /**
+    * Subscribe to notifications from the server about the given model, including live validation
+    * results.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    * @param timeout              a timeout, in milleseconds, after which idle time to close the subscription
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribeWithValidation(String modelUri, SubscriptionListener subscriptionListener, long timeout);
 
+   /**
+    * Subscribe to notifications from the server about the given model, including live validation
+    * results, in the given message {@code format}.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    * @param format               the format in which to encode the subscription messages
+    * @param timeout              a timeout, in milleseconds, after which idle time to close the subscription
+    *
+    * @see {@link #subscribe(String, SubscriptionListener, SubscriptionOptions)} for a more generic and flexible
+    *      way to specific subscription options
+    */
    void subscribeWithValidation(String modelUri, SubscriptionListener subscriptionListener, String format,
       long timeout);
+
+   /**
+    * Subscribe to notifications from the server about the given model.
+    *
+    * @param modelUri             the URI identifying the model to which to subscribe
+    * @param subscriptionListener the listener to call on subscription events
+    * @param options              the subscription options. May be {@code null} if no options are required
+    */
+   void subscribe(String modelUri, SubscriptionListener subscriptionListener, SubscriptionOptions options);
 
    boolean send(String modelUri, String message);
 

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/SubscriptionOptions.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/SubscriptionOptions.java
@@ -1,0 +1,282 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.client;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2;
+import org.eclipse.emfcloud.modelserver.jsonpatch.JsonPatch;
+import org.eclipse.emfcloud.modelserver.jsonpatch.Operation;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * An specification of subscription options.
+ */
+public interface SubscriptionOptions extends Serializable {
+   /**
+    * Query the subscription format.
+    *
+    * @return the subscription format, for example {@link ModelServerPathParametersV2#FORMAT_JSON_V2}
+    */
+   String getFormat();
+
+   /**
+    * Query whether the subscription includes live validation results.
+    *
+    * @return whether live validation is included in the subscription
+    */
+   boolean isLiveValidation();
+
+   /**
+    * Query the subscription timeout.
+    *
+    * @return the subscription timeout, in milliseconds
+    */
+   long getTimeout();
+
+   /**
+    * Query the subscription's scheme for the {@code path} property in JSON Patch operations
+    * in incremental update notifications.
+    *
+    * @return the operation path scheme, for example {@link ModelServerPathParametersV2#PATHS_JSON_POINTER}
+    */
+   String getPathScheme();
+
+   /**
+    * Query additional subscription options supported by the server.
+    *
+    * @return additional subscription options
+    */
+   Map<String, String> getAdditionalOptions();
+
+   /**
+    * Query whether the options include additional options not explicitly supported.
+    *
+    * @return whether any additional options are specified
+    */
+   default boolean hasAdditionalOptions() {
+      return !getAdditionalOptions().isEmpty();
+   }
+
+   /**
+    * Obtain a builder to create subscription options with suitable defaults, where applicable.
+    *
+    * @return a subscription options builder
+    */
+   static Builder builder() {
+      return new Impl.Builder();
+   }
+
+   //
+   // Nested types
+   //
+
+   /**
+    * A builder of {@link SubscriptionOptions} with suitable defaults, where applicable.
+    */
+   interface Builder {
+      /**
+       * Encode subscription messages in the given {@code format}.
+       *
+       * @param format the subscription format, for example {@link ModelServerPathParametersV2#FORMAT_JSON_V2}
+       * @return myself, for convenience of call chaining
+       */
+      Builder withFormat(String format);
+
+      /**
+       * Include live validation results in the subscription. Equivalent to
+       * {@link #withLiveValidation(boolean) withLiveValidation(true)}.
+       *
+       * @return myself, for convenience of call chaining
+       */
+      default Builder withLiveValidation() {
+         return withLiveValidation(true);
+      }
+
+      /**
+       * Optionally include live validation results in the subscription.
+       *
+       * @param validation whether to include live validation results
+       * @return myself, for convenience of call chaining
+       */
+      Builder withLiveValidation(boolean validation);
+
+      /**
+       * Time the subscription out after the given amount of idle time.
+       *
+       * @param timeout the timeout, measured in milliseconds
+       * @return myself, for convenience of call chaining
+       */
+      default Builder withTimeout(final long timeout) {
+         return withTimeout(timeout, TimeUnit.MILLISECONDS);
+      }
+
+      /**
+       * Time the subscription out after the given amount of idle time.
+       *
+       * @param timeout the timeout
+       * @param unit    the unit of measure of the {@code timeout}
+       * @return myself, for convenience of call chaining
+       */
+      Builder withTimeout(long timeout, TimeUnit unit);
+
+      /**
+       * Encode the {@code path} of {@link Operation}s in {@link JsonPatch} incremental update messages in the given
+       * scheme.
+       *
+       * @param pathScheme the path scheme, for example {@link ModelServerPathParametersV2#PATHS_JSON_POINTER}
+       * @return myself, for convenience of call chaining
+       */
+      Builder withPathScheme(String pathScheme);
+
+      /**
+       * Add a generic query parameter that is supported by the server's subscription URL.
+       *
+       * @param key   the parameter key
+       * @param value the parameter value
+       * @return myself, for convenience of call chaining
+       *
+       * @throws IllegalArgumentException if the {@code key} is a pre-defined subscription option
+       */
+      Builder withOption(String key, String value);
+
+      /**
+       * Create the subscription options.
+       *
+       * @return the subscription options
+       */
+      SubscriptionOptions build();
+   }
+
+   /**
+    * The immutable subscription options implementation.
+    */
+   final class Impl implements SubscriptionOptions {
+
+      private static final long serialVersionUID = 7218439084247958619L;
+
+      private String format;
+      private boolean liveValidation;
+      private long timeout;
+      private String pathScheme;
+      private Map<String, String> additionalOptions = Map.of();
+
+      private Impl() {
+         super();
+      }
+
+      @Override
+      public String getFormat() { return format; }
+
+      @Override
+      public boolean isLiveValidation() { return liveValidation; }
+
+      @Override
+      public long getTimeout() { return timeout; }
+
+      @Override
+      public String getPathScheme() { return pathScheme; }
+
+      @Override
+      public Map<String, String> getAdditionalOptions() { return additionalOptions; }
+
+      //
+      // Nested types
+      //
+
+      /**
+       * The subscription options builder.
+       */
+      static final class Builder implements SubscriptionOptions.Builder {
+         private Impl product = new Impl();
+         private ImmutableMap.Builder<String, String> additionalOptions;
+
+         private Impl finishProduct() {
+            Impl result = product();
+
+            if (additionalOptions != null) {
+               result.additionalOptions = additionalOptions.build();
+               additionalOptions = null;
+            }
+
+            return result;
+         }
+
+         private Impl product() {
+            if (product == null) {
+               product = new Impl();
+            }
+            return product;
+         }
+
+         @Override
+         public Builder withFormat(final String format) {
+            product().format = format;
+            return this;
+         }
+
+         @Override
+         public Builder withLiveValidation(
+            final boolean validation) {
+
+            product().liveValidation = validation;
+            return this;
+         }
+
+         @Override
+         public Builder withTimeout(final long timeout,
+            final TimeUnit unit) {
+            product().timeout = unit.toMillis(timeout);
+            return this;
+         }
+
+         @Override
+         public Builder withPathScheme(
+            final String pathScheme) {
+            product().pathScheme = pathScheme;
+            return this;
+         }
+
+         @Override
+         public Builder withOption(final String key,
+            final String value) {
+
+            switch (key) {
+               case ModelServerPathParametersV2.FORMAT:
+               case ModelServerPathParametersV2.LIVE_VALIDATION:
+               case ModelServerPathParametersV2.TIMEOUT:
+               case ModelServerPathParametersV2.PATHS:
+                  throw new IllegalArgumentException(key);
+               default:
+                  if (additionalOptions == null) {
+                     additionalOptions = ImmutableMap.builder();
+                  }
+
+                  additionalOptions.put(key, value);
+                  break;
+            }
+
+            return this;
+         }
+
+         @Override
+         public SubscriptionOptions build() {
+            Impl result = finishProduct();
+            product = null;
+            return result;
+         }
+      }
+
+   }
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/XmiToEObjectSubscriptionListener.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/XmiToEObjectSubscriptionListener.java
@@ -39,6 +39,7 @@ public class XmiToEObjectSubscriptionListener extends EObjectSubscriptionListene
       onIncrementalUpdate((CCommandExecutionResult) command);
    }
 
+   @Override
    public void onIncrementalUpdate(final CCommandExecutionResult command) {}
 
    /**

--- a/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v2/ModelServerClientV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.client/src/org/eclipse/emfcloud/modelserver/client/v2/ModelServerClientV2.java
@@ -24,6 +24,7 @@ import org.eclipse.emfcloud.modelserver.client.ModelServerClientApi;
 import org.eclipse.emfcloud.modelserver.client.Response;
 import org.eclipse.emfcloud.modelserver.client.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.client.SubscriptionListener;
+import org.eclipse.emfcloud.modelserver.client.SubscriptionOptions;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2;
@@ -347,6 +348,13 @@ public class ModelServerClientV2 implements ModelServerClientApi<EObject>, Model
       final String format, final long timeout) {
 
       delegate.subscribeWithValidation(modelUri, subscriptionListener, format, timeout);
+   }
+
+   @Override
+   public void subscribe(final String modelUri, final SubscriptionListener subscriptionListener,
+      final SubscriptionOptions options) {
+
+      delegate.subscribe(modelUri, subscriptionListener, options);
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/ModelServerPathParametersV2.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/ModelServerPathParametersV2.java
@@ -39,4 +39,23 @@ public interface ModelServerPathParametersV2 {
     */
    String EMF_COMMAND = "modelserver.emfcommand";
 
+   /**
+    * Subscription parameter determining whether object paths (such as in JSON Patch operations)
+    * are encoded as JSON Pointers (per JSON Patch spec) or as EMF-style URI fragments.
+    * The default is {@link #PATHS_JSON_POINTER JSON Pointers}.
+    */
+   String PATHS = "paths";
+
+   /**
+    * Value of the {@link #PATHS paths} subscription parameter indicating to use standard JSON Pointers.
+    * This is the default if the {@code paths} parameter is omitted.
+    */
+   String PATHS_JSON_POINTER = "jsonpointer";
+
+   /**
+    * Value of the {@link #PATHS paths} subscription parameter indicating to use the URI fragments of
+    * the underlying resource (usually the EMF objects' IDs in the resource).
+    */
+   String PATHS_URI_FRAGMENTS = "urifragments";
+
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionController.java
@@ -12,6 +12,8 @@ package org.eclipse.emfcloud.modelserver.emf.common;
 
 import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1.LIVE_VALIDATION;
 import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1.TIMEOUT;
+import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2.PATHS;
+import static org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2.PATHS_URI_FRAGMENTS;
 import static org.eclipse.emfcloud.modelserver.emf.common.JsonResponse.dirtyState;
 import static org.eclipse.emfcloud.modelserver.emf.common.JsonResponse.fullUpdate;
 import static org.eclipse.emfcloud.modelserver.emf.common.JsonResponse.validationResult;
@@ -35,13 +37,20 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
+import org.eclipse.emfcloud.modelserver.emf.common.util.ContextRequest;
+import org.eclipse.emfcloud.modelserver.emf.util.JsonPatchHelper;
+import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
@@ -63,6 +72,9 @@ public class DefaultSessionController implements SessionController {
 
    @Inject
    protected ModelValidator modelValidator;
+
+   @Inject
+   protected JsonPatchHelper patchHelper;
 
    @Override
    public boolean subscribe(final WsContext client, final String modeluri) {
@@ -248,7 +260,40 @@ public class DefaultSessionController implements SessionController {
    }
 
    protected void broadcastIncrementalUpdatesV2(final String modeluri, final JsonNode jsonPatch) {
-      getOpenSessionsV2(modeluri).forEach(session -> session.send(JsonResponse.incrementalUpdate(jsonPatch)));
+      final Supplier<JsonNode> patchWithURIFragments = Suppliers
+         .memoize(() -> rewritePathsAsURIFragments(modeluri, jsonPatch));
+
+      getOpenSessionsV2(modeluri).forEach(session -> {
+         if (isPathsAsURIFragments(session)) {
+            session.send(JsonResponse.incrementalUpdate(patchWithURIFragments.get()));
+         } else {
+            session.send(JsonResponse.incrementalUpdate(jsonPatch));
+         }
+      });
+   }
+
+   protected boolean isPathsAsURIFragments(final WsContext session) {
+      return ContextRequest.getParam(session, PATHS).filter(PATHS_URI_FRAGMENTS::equalsIgnoreCase).isPresent();
+   }
+
+   protected JsonNode rewritePathsAsURIFragments(final String modeluri, final JsonNode jsonPatch) {
+      JsonNode result = jsonPatch.deepCopy();
+
+      for (JsonNode next : jsonPatch.isArray() ? result : Collections.singleton(result)) {
+         if (next.isObject() && next.has("op") && next.has("path")) {
+            ObjectNode operation = (ObjectNode) next;
+            resolvePathAsURIFragment(modeluri, operation.get("path").asText())
+               .ifPresent(path -> operation.set("path", Json.text(path)));
+         }
+      }
+
+      return result;
+   }
+
+   protected Optional<String> resolvePathAsURIFragment(final String modeluri, final String jsonPointer) {
+      Optional<ResourceSet> resourceSet = modelRepository.getModel(modeluri).map(EObject::eResource)
+         .map(Resource::getResourceSet);
+      return resourceSet.flatMap(rset -> patchHelper.toURIFragmentPath(modeluri, rset, jsonPointer));
    }
 
    private void broadcastIncrementalUpdate(final WsContext session, final Map<String, JsonNode> updates) {

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelURIConverter.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelURIConverter.java
@@ -17,6 +17,7 @@ import static org.eclipse.emfcloud.modelserver.emf.common.util.ContextResponse.m
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -203,6 +204,26 @@ public interface ModelURIConverter extends URIConverter {
     */
    default String deresolveModelURI(final WsContext ctx, final String modelURI) {
       return deresolveModelURI(ctx, URI.createURI(modelURI)).toString();
+   }
+
+   /**
+    * Encapsulate the given request context in a function that deresolves model URIs.
+    *
+    * @param ctx the current request context
+    * @return a model URI deresolving function
+    */
+   default UnaryOperator<String> deresolver(final Context ctx) {
+      return modeluri -> deresolveModelURI(ctx, modeluri);
+   }
+
+   /**
+    * Encapsulate the given websocket session context in a function that deresolves model URIs.
+    *
+    * @param ctx the current websocket session context
+    * @return a model URI deresolving function
+    */
+   default UnaryOperator<String> deresolver(final WsContext ctx) {
+      return modeluri -> deresolveModelURI(ctx, modeluri);
    }
 
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/util/ContextRequest.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/util/ContextRequest.java
@@ -40,6 +40,10 @@ public final class ContextRequest {
       return getParam(context.queryParamMap(), paramKey);
    }
 
+   public static Optional<String> getParam(final WsContext context, final String paramKey) {
+      return getParam(context.queryParamMap(), paramKey);
+   }
+
    public static Optional<String> getParam(final Map<String, List<String>> queryParams, final String paramKey) {
       return queryParams.containsKey(paramKey)
          ? Optional.ofNullable(queryParams.get(paramKey).get(0))

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultSessionControllerTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,6 +37,7 @@ import org.eclipse.emfcloud.modelserver.edit.CommandExecutionType;
 import org.eclipse.emfcloud.modelserver.edit.EMFCommandType;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecsManager;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+import org.eclipse.emfcloud.modelserver.emf.util.JsonPatchHelper;
 import org.eclipse.emfcloud.modelserver.jsonschema.Json;
 import org.eclipse.jetty.websocket.api.Session;
 import org.hamcrest.CustomTypeSafeMatcher;
@@ -80,6 +81,8 @@ public class DefaultSessionControllerTest {
    private CodecsManager codecs;
    @Mock
    private ModelValidator modelValidator;
+   @Mock
+   private JsonPatchHelper jsonPatchHelper;
 
    private DefaultSessionController sessionController;
 
@@ -262,6 +265,7 @@ public class DefaultSessionControllerTest {
    @Before
    public void createSessionController() {
       sessionController = Guice.createInjector(new AbstractModule() {
+
          @Override
          protected void configure() {
             bind(ServerConfiguration.class).toInstance(serverConfig);
@@ -270,6 +274,7 @@ public class DefaultSessionControllerTest {
             bind(ModelResourceManager.class).toInstance(modelResourceManager);
             bind(CodecsManager.class).toInstance(codecs);
             bind(ModelValidator.class).toInstance(modelValidator);
+            bind(JsonPatchHelper.class).toInstance(jsonPatchHelper);
          }
       }).getInstance(DefaultSessionController.class);
    }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelperTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelperTest.java
@@ -1,0 +1,115 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.util;
+
+import static org.eclipse.emfcloud.modelserver.tests.util.MoreMatchers.emptyOptional;
+import static org.eclipse.emfcloud.modelserver.tests.util.MoreMatchers.presentValueThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.xmi.impl.EcoreResourceFactoryImpl;
+import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
+import org.eclipse.emfcloud.modelserver.common.utils.MapBinding;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelURIConverter;
+import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
+import org.eclipse.emfcloud.modelserver.emf.di.MultiBindingDefaults;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JsonPatchHelperTest {
+
+   private String modelURI;
+
+   private ResourceSet resourceSet;
+
+   @Mock
+   private ServerConfiguration serverConfiguration;
+
+   @Mock
+   private ModelResourceManager modelResourceManager;
+
+   @Mock
+   private ModelURIConverter modelURIConverter;
+
+   private JsonPatchHelper patchHelper;
+
+   public JsonPatchHelperTest() {
+      super();
+   }
+
+   @Test
+   public void toURIFragmentPath() {
+      Optional<String> path = patchHelper.toURIFragmentPath(modelURI, resourceSet,
+         "/eClassifiers/2/eStructuralFeatures/3/name");
+      assertThat(path, presentValueThat(is("#//ControlUnit/display/name")));
+   }
+
+   @Test
+   public void toURIFragmentPath_unresolved() {
+      Optional<String> path = patchHelper.toURIFragmentPath(modelURI, resourceSet,
+         "/eClassifiers/2/eBogusFeatures/3/name");
+      assertThat(path, emptyOptional());
+   }
+
+   //
+   // Test framework
+   //
+
+   @Before
+   public void createModelFixture() {
+      resourceSet = new ResourceSetImpl();
+      resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore", new EcoreResourceFactoryImpl());
+
+      File file = new File("resources/Coffee.ecore");
+      URI uri = URI.createFileURI(file.getAbsolutePath());
+      modelURI = uri.toString();
+      resourceSet.getResource(uri, true);
+   }
+
+   @Before
+   public void configureMocks() {
+      when(modelURIConverter.normalize(ArgumentMatchers.any(URI.class))).then(invocation -> invocation.getArgument(0));
+      when(modelResourceManager.loadResource(ArgumentMatchers.anyString())).then(
+         invocation -> Optional.ofNullable(resourceSet.getResource(URI.createURI(invocation.getArgument(0)), true)));
+   }
+
+   @Before
+   public void createTestSubject() {
+      patchHelper = Guice.createInjector(new AbstractModule() {
+         @Override
+         protected void configure() {
+            bind(ServerConfiguration.class).toInstance(serverConfiguration);
+            bind(ModelResourceManager.class).toInstance(modelResourceManager);
+            bind(ModelURIConverter.class).toInstance(modelURIConverter);
+
+            MapBinding<String, Codec> codecBinding = MapBinding.create(String.class, Codec.class);
+            codecBinding.putAll(MultiBindingDefaults.DEFAULT_CODECS);
+            codecBinding.applyBinding(binder());
+         }
+      }).getInstance(JsonPatchHelper.class);
+   }
+}

--- a/tests/org.eclipse.emfcloud.modelserver.tests/src/org/eclipse/emfcloud/modelserver/tests/util/MoreMatchers.java
+++ b/tests/org.eclipse.emfcloud.modelserver.tests/src/org/eclipse/emfcloud/modelserver/tests/util/MoreMatchers.java
@@ -10,10 +10,12 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.tests.util;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
 
 /**
@@ -45,4 +47,41 @@ public final class MoreMatchers {
       };
    }
 
+   public static <T> Matcher<Optional<T>> presentValueThat(final Matcher<? super T> valueMatcher) {
+      return new TypeSafeDiagnosingMatcher<>() {
+         @Override
+         public void describeTo(final Description description) {
+            description.appendText("present Optional that ");
+            description.appendDescriptionOf(valueMatcher);
+         }
+
+         @Override
+         protected boolean matchesSafely(final Optional<T> item, final Description mismatchDescription) {
+            if (item.isEmpty()) {
+               mismatchDescription.appendText("empty Optional");
+               return false;
+            }
+            if (!valueMatcher.matches(item.get())) {
+               mismatchDescription.appendText("value that ");
+               valueMatcher.describeMismatch(item.get(), mismatchDescription);
+               return false;
+            }
+            return true;
+         }
+      };
+   }
+
+   public static <T> Matcher<Optional<T>> emptyOptional() {
+      return new TypeSafeMatcher<>() {
+         @Override
+         public void describeTo(final Description description) {
+            description.appendText("empty optional");
+         }
+
+         @Override
+         protected boolean matchesSafely(final Optional<T> item) {
+            return item.isEmpty();
+         }
+      };
+   }
 }


### PR DESCRIPTION
As described in the feature request, add a new subscription parameter for `paths` scheme.
Now, with the `paths=uriFragments` query parameter in the `/api/v2/subscribe` request, the `Operation`s in JSON Patches provided by the server in incremental update notifications will have `path` properties of the form

`#_0uuid6017-fun/feature/3`

whereas otherwise they have the form

`/path/1/through/3/containment/0/references/7/to/0/a/1/feature/-`

Note that the resource URI is not included; only the fragment portion. A future enhancement can include resources URIs when they are necessary either to disambiguate operations on objects in different resources or when the resource URI is different to the `modeluri` parameter of the subscription. This is for now on par with the JSON Pointer scheme, which also does not support multiple resources (see #159 for more on that).

Also incidentally fix a compiler warning introduced by an earlier PR.

Resolves #205

Contributed on behalf of STMicroelectronics.
