### PR TITLE
#200 Follow-up - Revert examples module integration in deploy build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
 
 	<modules>
 		<module>bundles</module>
-		<module>examples</module>
 	</modules>
 
 	<!-- Properties -->
@@ -582,6 +581,7 @@
 				</property>
 			</activation>
 			<modules>
+				<module>examples</module>
 				<module>releng</module>
 				<module>tests</module>
 			</modules>


### PR DESCRIPTION
- Revert examples directory exclusion for m2 deployment
- Deploy job can publish example modules without -DpluginsOnly argument
- Release job uses argument -DpluginsOnly to avoid publishing the example module