### PR TITLE
212: API V2: IndexOutOfBoundsException when closing Transaction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
             steps {
                 // ignore test failures since we parse the test results afterwards
                 timeout(30) {
-                    sh 'mvn clean verify -Pm2 -B -Dmaven.test.failure.ignore=true'
+                    sh 'mvnw clean verify -Pm2 -B -Dmaven.test.failure.ignore=true'
                 } 
             }
         }
@@ -20,7 +20,7 @@ pipeline {
             steps {
                 // ignore test failures since we parse the test results afterwards
                 timeout(30) {
-                    sh 'mvn clean verify -Pp2 -B -Dmaven.test.failure.ignore=true' 
+                    sh 'mvnw clean verify -Pp2 -B -Dmaven.test.failure.ignore=true' 
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
             steps {
                 // ignore test failures since we parse the test results afterwards
                 timeout(30) {
-                    sh 'mvnw clean verify -Pm2 -B -Dmaven.test.failure.ignore=true'
+                    sh './mvnw clean verify -Pm2 -B -Dmaven.test.failure.ignore=true'
                 } 
             }
         }
@@ -20,7 +20,7 @@ pipeline {
             steps {
                 // ignore test failures since we parse the test results afterwards
                 timeout(30) {
-                    sh 'mvnw clean verify -Pp2 -B -Dmaven.test.failure.ignore=true' 
+                    sh './mvnw clean verify -Pp2 -B -Dmaven.test.failure.ignore=true' 
                 }
             }
         }


### PR DESCRIPTION
Fix the behavior of TransactionContext.close() by using a CompositeChangeDescription instead of merging instances of ChangeDescription.

Contributed on behalf of STMicroelectronics.