### PR TITLE
GH-209: API V2: Return patches for each affected resource

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelListener.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelListener.java
@@ -10,8 +10,10 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -41,7 +43,7 @@ public interface ModelListener {
     *                     Not itself {@code null} but it can supply a {@code null} if for some reason it is unavailable
     */
    default void commandExecuted(final String modeluri, final Supplier<? extends CCommandExecutionResult> execution,
-      final Supplier<? extends JsonNode> patch) {
+      final Supplier<Map<URI, JsonNode>> patch) {
 
       CCommandExecutionResult result = execution.get();
       if (result != null) {

--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/ExampleServerModule.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/ExampleServerModule.java
@@ -10,6 +10,9 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.example;
 
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
 import org.eclipse.emfcloud.modelserver.common.Routing;
 import org.eclipse.emfcloud.modelserver.common.utils.MapBinding;
 import org.eclipse.emfcloud.modelserver.common.utils.MultiBinding;
@@ -35,5 +38,15 @@ public class ExampleServerModule extends DefaultModelServerModule {
    protected void configureCommandCodecs(final MapBinding<String, CommandContribution> binding) {
       super.configureCommandCodecs(binding);
       binding.put(UpdateTaskNameCommandContribution.TYPE, UpdateTaskNameCommandContribution.class);
+   }
+
+   @Override
+   protected AdapterFactory provideAdapterFactory() {
+      AdapterFactory provideAdapterFactory = super.provideAdapterFactory();
+      ComposedAdapterFactory factory = provideAdapterFactory instanceof ComposedAdapterFactory
+         ? (ComposedAdapterFactory) provideAdapterFactory
+         : new ComposedAdapterFactory(provideAdapterFactory);
+      factory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+      return provideAdapterFactory;
    }
 }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
@@ -297,6 +297,7 @@ public class DefaultModelControllerTest {
    }
 
    @Test
+   @SuppressWarnings("unchecked")
    public void undoRedo() throws EncodingException, DecodingException {
       ResourceSet rset = new ResourceSetImpl();
       String modeluri = "SuperBrewer3000.json";
@@ -336,10 +337,11 @@ public class DefaultModelControllerTest {
          .thenReturn(Optional.of(CCommandFactory.eINSTANCE.createCommandExecutionResult()));
       when(modelRepository.redo(modeluri))
          .thenReturn(Optional.of(CCommandFactory.eINSTANCE.createCommandExecutionResult()));
-      when(jsonPatchHelper.getJsonPatch(any(), any())).thenReturn(
-         Json.array(Json.object(Map.of("op", Json.text("add")))),
-         Json.array(Json.object(Map.of("op", Json.text("remove")))),
-         Json.array(Json.object(Map.of("op", Json.text("add")))));
+      URI uri = URI.createURI(modeluri);
+      when(jsonPatchHelper.getJsonPatches(any(), any())).thenReturn(
+         Map.of(uri, Json.array(Json.object(Map.of("op", Json.text("add"))))),
+         Map.of(uri, Json.array(Json.object(Map.of("op", Json.text("remove"))))),
+         Map.of(uri, Json.array(Json.object(Map.of("op", Json.text("add"))))));
 
       modelController.executeCommand(context, modeluri);
 


### PR DESCRIPTION
Change the return value of edit, undo and redo operations, to return one patch per modified resource, in addition to the main-resource patch.

Before:

```json
{
    "type": "success",
    "data": {
        "message": "Model 'SuperBrewer3000.coffee' successfully updated",
        "patch": [
            {
                "op": "remove",
                "path": "/workflows/0/nodes"
            }
        ]
    }
}
```
After:
```json
{
    "type": "success",
    "data": {
        "message": "Model 'SuperBrewer3000.coffee' successfully updated",
        "patch": [
            {
                "op": "remove",
                "path": "/workflows/0/nodes"
            }
        ],
        "allPatches": [
            {
                "modelUri": "file:/home/camille/Git/modelserver/examples/org.eclipse.emfcloud.modelserver.example/.temp/workspace/SuperBrewer3000.coffee",
                "patch": [
                    {
                        "op": "remove",
                        "path": "/workflows/0/nodes"
                    }
                ]
            }
        ]
    }
}
```

Note that for the main resource, the patches are redundant. We could keep "allPatches" exclusively, but it would make everything a bit more complicated: with a main patch, we don't have to worry about modelUri at all in case of single-resource edition. With multiple-resources, we can rely on allPatches exclusively and ignore the main patch. Keeping both also means we don't break existing clients (and single-resource implementations do not need to change), which is a lot easier.

Contributed on behalf of STMicroelectronics.