### PR TITLE
220: API V2: JsonPatchHelper doesn't properly handle 'add' operations for single-valued references

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/patch/AbstractJsonPatchHelper.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/patch/AbstractJsonPatchHelper.java
@@ -291,9 +291,13 @@ public abstract class AbstractJsonPatchHelper {
          }
       }
 
-      Command create = AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
-         setting.getFeature(), Collections.singleton(objectToAdd));
-      result = result == null ? create : result.chain(create);
+      Command addOrSet = feature.isMany()
+         ? AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
+            setting.getFeature(), Collections.singleton(objectToAdd))
+         : SetCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(), feature,
+            objectToAdd);
+      result = result == null ? addOrSet : result.chain(addOrSet);
+
       return result;
    }
 


### PR DESCRIPTION
- Use distinct commands for single-valued and multi-valued references

Fixes #220

Contributed on behalf of STMicroelectronics.