### PR TITLE
Add missing jars in lib project

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.lib/build.properties
+++ b/bundles/org.eclipse.emfcloud.modelserver.lib/build.properties
@@ -1,15 +1,4 @@
 bin.includes = META-INF/,\
                .,\
-               lib/annotations-20.1.0.jar,\
-               lib/commons-cli-1.4.jar,\
-               lib/kotlin-stdlib-1.4.10.jar,\
-               lib/kotlin-stdlib-common-1.4.10.jar,\
-               lib/okhttp-4.9.1.jar,\
-               lib/okio-2.10.0.jar,\
-               lib/javalin-4.3.0.jar,\
-               lib/websocket-api-9.4.44.v20210927.jar,\
-               lib/websocket-servlet-9.4.44.v20210927.jar
-               lib/btf-1.3.jar,\
-               lib/jackson-coreutils-2.0.jar,\
-               lib/json-patch-1.13.jar,\
-               lib/msg-simple-1.2.jar
+               lib/
+bin.excludes = lib/*-sources.jar


### PR DESCRIPTION
Without the jars the bundle cannot be consumed by p2 correctly as a
ClassNotFoundException is thrown.