### PR TITLE
240: JSON Patch: Object not added at index specified in add op

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/patch/AbstractJsonPatchHelper.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/patch/AbstractJsonPatchHelper.java
@@ -239,8 +239,11 @@ public abstract class AbstractJsonPatchHelper {
          // Attributes
          Object emfValue = getEMFValue(modelURI, resourceSet, feature, value);
          result = setting.getFeature().isMany()
-            ? AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
-               feature, Collections.singleton(emfValue))
+            ? setting.getIndex()
+               .map(index -> AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
+                  feature, Collections.singleton(emfValue), index))
+               .orElseGet(() -> AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
+                  feature, Collections.singleton(emfValue)))
             : SetCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(), feature,
                emfValue);
       }
@@ -287,8 +290,11 @@ public abstract class AbstractJsonPatchHelper {
       }
 
       Command addOrSet = feature.isMany()
-         ? AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
-            setting.getFeature(), Collections.singleton(objectToAdd))
+         ? setting.getIndex()
+            .map(index -> AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
+               setting.getFeature(), Collections.singleton(objectToAdd), index))
+            .orElseGet(() -> AddCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(),
+               setting.getFeature(), Collections.singleton(objectToAdd)))
          : SetCommand.create(getEditingDomain(setting.getEObject()), setting.getEObject(), feature,
             objectToAdd);
       result = result == null ? addOrSet : result.chain(addOrSet);

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/Test1.ecore
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/Test1.ecore
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="test1" nsURI="">
+<ecore:EPackage xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    name="test1" nsURI="http://www.eclipse.org/emfcloud/modelserver/2022/test"
+    nsPrefix="test">
   <eClassifiers xsi:type="ecore:EClass" name="AbstractClass1" abstract="true">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="Name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ConcreteClass1" eSuperTypes="#//AbstractClass1">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiValuedAttr" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/Test1.json
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/Test1.json
@@ -1,7 +1,8 @@
 {
   "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EPackage",
   "name" : "test1",
-  "nsURI" : "",
+  "nsPrefix": "test",
+  "nsURI" : "http://www.eclipse.org/emfcloud/modelserver/2022/test",
   "eClassifiers" : [ {
     "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EClass",
     "name" : "AbstractClass1",
@@ -28,6 +29,15 @@
         "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
         "$ref" : "http://www.eclipse.org/emf/2002/Ecore#//EString"
       }
+    },
+    {
+      "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+      "name" : "multiValuedAttr",
+      "eType" : {
+        "eClass" : "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
+        "$ref" : "http://www.eclipse.org/emf/2002/Ecore#//EString"
+      },
+      "upperBound" : -1
     } ]
   } ]
 }

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/aConcreteClass1.xmi
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/resources/aConcreteClass1.xmi
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test:ConcreteClass1
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:test="http://www.eclipse.org/emfcloud/modelserver/2022/test"
+    xsi:schemaLocation="http://www.eclipse.org/emfcloud/modelserver/2022/test Test1.ecore"
+    Name="Test Instance"
+    type="testing">
+  <multiValuedAttr>a</multiValuedAttr>
+  <multiValuedAttr>b</multiValuedAttr>
+  <multiValuedAttr>c</multiValuedAttr>
+</test:ConcreteClass1>

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelperTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/util/JsonPatchHelperTest.java
@@ -10,21 +10,31 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.util;
 
+import static org.eclipse.emfcloud.modelserver.tests.util.EMFMatchers.eNamedElement;
+import static org.eclipse.emfcloud.modelserver.tests.util.EMFMatchers.eObjectOfClass;
 import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EAnnotation;
+import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcoreFactory;
@@ -36,26 +46,39 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.impl.EcoreResourceFactoryImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import org.eclipse.emf.edit.command.AddCommand;
+import org.eclipse.emf.edit.command.CommandParameter;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
+import org.eclipse.emfcloud.modelserver.common.patch.JsonPatchException;
+import org.eclipse.emfcloud.modelserver.common.patch.JsonPatchTestException;
 import org.eclipse.emfcloud.modelserver.common.utils.MultiBinding;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelServerEditingDomain;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecProvider;
+import org.eclipse.emfcloud.modelserver.emf.common.codecs.JsonCodecV2;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.di.MultiBindingDefaults;
+import org.eclipse.emfcloud.modelserver.jsonschema.Json;
+import org.eclipse.emfcloud.modelserver.jsonschema.JsonConstants;
+import org.hamcrest.Matcher;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 
@@ -71,6 +94,12 @@ public class JsonPatchHelperTest {
 
    @Mock(answer = Answers.RETURNS_MOCKS)
    private ModelServerEditingDomain editingDomain;
+
+   @Captor
+   private ArgumentCaptor<Class<? extends Command>> commandClassCaptor;
+
+   @Captor
+   private ArgumentCaptor<CommandParameter> commandParameterCaptor;
 
    @Mock
    private ServerConfiguration serverConfiguration;
@@ -156,6 +185,93 @@ public class JsonPatchHelperTest {
       assertThat(uri, endsWith("Coffee.ecore#//Component/eStructuralFeatures/2"));
    }
 
+   @Test
+   public void add_containmentReference() throws JsonPatchException, JsonPatchTestException {
+      ObjectNode addOp = Json
+         .object(Map.of("op", Json.text("add"), "path", Json.text("/eClassifiers/0/eStructuralFeatures")));
+      EStructuralFeature attr = EcoreFactory.eINSTANCE.createEAttribute();
+      attr.setName("newAttribute");
+      addOp.set("value", encode(attr));
+
+      verifyAddCommand(addOp,
+         eNamedElement(EClass.class, "Component"),
+         is(EcorePackage.Literals.ECLASS__ESTRUCTURAL_FEATURES),
+         eNamedElement(EAttribute.class, "newAttribute"),
+         is(CommandParameter.NO_INDEX));
+   }
+
+   @Test
+   public void add_containmentReference_explicitAppend() throws JsonPatchException, JsonPatchTestException {
+      ObjectNode addOp = Json
+         .object(Map.of("op", Json.text("add"), "path", Json.text("/eClassifiers/0/eStructuralFeatures/-")));
+      EStructuralFeature attr = EcoreFactory.eINSTANCE.createEAttribute();
+      attr.setName("newAttribute");
+      addOp.set("value", encode(attr));
+
+      verifyAddCommand(addOp,
+         eNamedElement(EClass.class, "Component"),
+         is(EcorePackage.Literals.ECLASS__ESTRUCTURAL_FEATURES),
+         eNamedElement(EAttribute.class, "newAttribute"),
+         is(CommandParameter.NO_INDEX));
+   }
+
+   @Test
+   public void add_containmentReference_withIndex() throws JsonPatchException, JsonPatchTestException {
+      ObjectNode addOp = Json
+         .object(Map.of("op", Json.text("add"), "path", Json.text("/eClassifiers/0/eStructuralFeatures/2")));
+      EStructuralFeature attr = EcoreFactory.eINSTANCE.createEAttribute();
+      attr.setName("newAttribute");
+      addOp.set("value", encode(attr));
+
+      verifyAddCommand(addOp,
+         eNamedElement(EClass.class, "Component"),
+         is(EcorePackage.Literals.ECLASS__ESTRUCTURAL_FEATURES),
+         eNamedElement(EAttribute.class, "newAttribute"),
+         is(2));
+   }
+
+   @Test
+   public void add_attribute() throws JsonPatchException, JsonPatchTestException {
+      ObjectNode addOp = Json
+         .object(Map.of("op", Json.text("add"), //
+            "path", Json.text("/eAnnotations/0/contents/0/multiValuedAttr"), //
+            "value", Json.text("d")));
+
+      verifyAddCommand(addOp,
+         eObjectOfClass("ConcreteClass1"),
+         eNamedElement(EAttribute.class, "multiValuedAttr"),
+         is("d"),
+         is(CommandParameter.NO_INDEX));
+   }
+
+   @Test
+   public void add_attribute_explicitAppend() throws JsonPatchException, JsonPatchTestException {
+      ObjectNode addOp = Json
+         .object(Map.of("op", Json.text("add"), //
+            "path", Json.text("/eAnnotations/0/contents/0/multiValuedAttr/-"), //
+            "value", Json.text("d")));
+
+      verifyAddCommand(addOp,
+         eObjectOfClass("ConcreteClass1"),
+         eNamedElement(EAttribute.class, "multiValuedAttr"),
+         is("d"),
+         is(CommandParameter.NO_INDEX));
+   }
+
+   @Test
+   public void add_attribute_withIndex() throws JsonPatchException, JsonPatchTestException {
+      ObjectNode addOp = Json
+         .object(Map.of("op", Json.text("add"), //
+            "path", Json.text("/eAnnotations/0/contents/0/multiValuedAttr/2"), //
+            "value", Json.text("d")));
+
+      verifyAddCommand(addOp,
+         eObjectOfClass("ConcreteClass1"),
+         eNamedElement(EAttribute.class, "multiValuedAttr"),
+         is("d"),
+         is(2));
+   }
+
    //
    // Test framework
    //
@@ -164,14 +280,28 @@ public class JsonPatchHelperTest {
    public void createModelFixture() {
       resourceSet = new ResourceSetImpl();
       resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore", new EcoreResourceFactoryImpl());
+      resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("*", new XMIResourceFactoryImpl());
       Resource resource = resourceSet.getResource(modelURI, true);
       coffeePackage = (EPackage) resource.getContents().get(0);
+
+      // Mix in objects for testing other kinds of features not found in Ecore
+      URI extraURI = URI.createURI("aConcreteClass1.xmi").resolve(modelURI);
+      Resource extra = resourceSet.getResource(extraURI, true);
+
+      EAnnotation annotation = EcoreFactory.eINSTANCE.createEAnnotation();
+      annotation.setSource("testing");
+      annotation.getContents().addAll(extra.getContents());
+      coffeePackage.getEAnnotations().add(annotation);
+      extra.unload();
+      resourceSet.getResources().remove(extra);
    }
 
    @Before
    public void configureMocks() {
       when(modelURIConverter.normalize(modelURI)).thenReturn(modelURI);
       when(modelResourceManager.getEditingDomain(resourceSet)).thenReturn(editingDomain);
+      when(modelResourceManager.loadResource(ArgumentMatchers.anyString())).thenReturn(Optional.empty());
+      when(modelResourceManager.loadResource(modelURI.toString())).thenReturn(Optional.of(coffeePackage.eResource()));
    }
 
    @Before
@@ -221,5 +351,40 @@ public class JsonPatchHelperTest {
       URI result = uriFunction.apply(operation);
 
       return result == null ? null : result.toString();
+   }
+
+   JsonNode encode(final EObject object) {
+      JsonNode result;
+
+      try {
+         result = new JsonCodecV2().encode(object);
+
+         if (result.isObject() && object.eResource() == null) {
+            // Make sure there's no NullNode for the id
+            ObjectNode objectNode = (ObjectNode) result;
+            if (objectNode.has(JsonConstants.ID_ATTR)) {
+               objectNode.remove(JsonConstants.ID_ATTR);
+            }
+         }
+      } catch (EncodingException e) {
+         throw new AssertionError("Failed to encode object", e);
+      }
+
+      return result;
+   }
+
+   void verifyAddCommand(final JsonNode addOp, final Matcher<Object> owner, final Matcher<Object> feature,
+      final Matcher<Object> item, final Matcher<Integer> index) throws JsonPatchException, JsonPatchTestException {
+      ArrayNode patch = Json.array(addOp);
+      patchHelper.getCommand(modelURI.toString(), resourceSet, patch);
+
+      verify(editingDomain).createCommand(commandClassCaptor.capture(), commandParameterCaptor.capture());
+      assertThat(commandClassCaptor.getValue(), sameInstance(AddCommand.class));
+      CommandParameter param = commandParameterCaptor.getValue();
+
+      assertThat(param.getOwner(), owner);
+      assertThat(param.getFeature(), feature);
+      assertThat(param.getCollection(), hasItem(item));
+      assertThat(param.getIndex(), index);
    }
 }

--- a/tests/org.eclipse.emfcloud.modelserver.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.emfcloud.modelserver.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.emf.common;bundle-version="[2.17.0,3.0.0)",
  org.eclipse.emf.ecore;bundle-version="[2.20.0,3.0.0)",
  org.eclipse.emf.edit;bundle-version="[2.16.0,3.0.0)",
  org.eclipse.emfcloud.modelserver.lib;bundle-version="[0.7.0,1.0.0)",
- org.hamcrest.library;bundle-version="1.3.0"
+ org.hamcrest.library;bundle-version="[1.3.0,2.0.0)",
+ org.hamcrest.core;bundle-version="[1.3.0,2.0.0)"
 Export-Package: okhttp3.mock,
  okhttp3.mock.matchers,
  org.eclipse.emfcloud.modelserver.tests.util

--- a/tests/org.eclipse.emfcloud.modelserver.tests/src/org/eclipse/emfcloud/modelserver/tests/util/EMFMatchers.java
+++ b/tests/org.eclipse.emfcloud.modelserver.tests/src/org/eclipse/emfcloud/modelserver/tests/util/EMFMatchers.java
@@ -10,6 +10,10 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.tests.util;
 
+import static org.hamcrest.CoreMatchers.both;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -19,6 +23,8 @@ import java.util.Set;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CompoundCommand;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.ENamedElement;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -26,6 +32,7 @@ import org.eclipse.emf.edit.command.AddCommand;
 import org.eclipse.emf.edit.command.RemoveCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
 /**
@@ -161,6 +168,35 @@ public final class EMFMatchers {
             return false;
          }
       };
+   }
+
+   public static Matcher<Object> eNamedElement(final Class<? extends ENamedElement> expectedType, final String name) {
+      return eNamedElement(expectedType, is(name));
+   }
+
+   public static Matcher<Object> eNamedElement(final Class<? extends ENamedElement> expectedType,
+      final Matcher<? super String> nameMatcher) {
+      Matcher<Object> typeFeature = instanceOf(expectedType);
+      @SuppressWarnings({ "unchecked", "rawtypes" })
+      Matcher<Object> nameFeature = (Matcher) new FeatureMatcher<ENamedElement, String>(nameMatcher, "name", "name") {
+         @Override
+         protected String featureValueOf(final ENamedElement actual) {
+            return actual.getName();
+         }
+      };
+
+      return both(typeFeature).and(nameFeature);
+   }
+
+   public static Matcher<Object> eObjectOfClass(final String eClassName) {
+      return new CustomTypeSafeMatcher<>("EObject of class " + eClassName) {
+         @Override
+         protected boolean matchesSafely(final Object item) {
+            EClass eClass = (item instanceof EObject) ? ((EObject) item).eClass() : null;
+            return eClass != null && Objects.equals(eClass.getName(), eClassName);
+         }
+      };
+
    }
 
 }


### PR DESCRIPTION
Insert at the index given by the path when an index is specified, for both `EReference`s and `EAttribute`s.

Fixes #240

Contributed on behalf of STMicroelectronics.
