### PR TITLE
Do not reuse object mapper

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ProviderDefaults.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/ProviderDefaults.java
@@ -24,7 +24,6 @@ import io.javalin.plugin.json.JavalinJackson;
 public final class ProviderDefaults {
    protected static final Logger LOG = LogManager.getLogger(ProviderDefaults.class);
 
-   private static ObjectMapper objectMapper = EMFModule.setupDefaultMapper();
    private static boolean isDevLoggingEnabled;
 
    private ProviderDefaults() {}
@@ -34,7 +33,7 @@ public final class ProviderDefaults {
    }
 
    public static ObjectMapper provideObjectMapper() {
-      return ProviderDefaults.objectMapper;
+      return EMFModule.setupDefaultMapper();
    }
 
    public static void enableDevLogging() {


### PR DESCRIPTION
Reusing the object mapper can lead to problems.
For example the validation dynamically adds the resource to allow for id mapping.
Hence, a new object mapper is needed each time as the resource might change.