### PR TITLE
245: Codecs looked up by workspace URI

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/APIVersion.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.common/src/org/eclipse/emfcloud/modelserver/common/APIVersion.java
@@ -167,6 +167,10 @@ public final class APIVersion implements Comparable<APIVersion> {
     * @return the API version, or {@link #ZERO} if the URI is not a versioned API request URI
     */
    public static APIVersion forRequestURI(final String requestURI) {
+      if (requestURI == null) {
+         return ZERO;
+      }
+
       Matcher m = API_PATTERN.matcher(requestURI);
       return m.find() ? APIVersion.of(Integer.parseInt(m.group(1))) : ZERO;
    }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelResourceManager.java
@@ -314,9 +314,10 @@ public class DefaultModelResourceManager implements ModelResourceManager {
       try {
          ResourceSet rset = getResourceSet(modeluri);
          URI resourceURI = createURI(modeluri);
-         Optional<Resource> loadedResource = Optional.ofNullable(rset.getResource(resourceURI, false))
+         // Note that the resource set may be absent if the resource does not exist
+         Optional<Resource> loadedResource = Optional.ofNullable(rset).map(rs -> rs.getResource(resourceURI, false))
             .filter(Resource::isLoaded);
-         if (loadedResource.isPresent()) {
+         if (loadedResource.isPresent() || rset == null) {
             return loadedResource;
          }
          // do load the resource and watch for modifications
@@ -324,7 +325,7 @@ public class DefaultModelResourceManager implements ModelResourceManager {
          resource.load(Collections.EMPTY_MAP);
          watchResourceModifications(resource);
          return Optional.of(resource);
-      } catch (final Throwable e) {
+      } catch (final Exception e) {
          handleLoadError(modeluri, this.isInitializing, e);
          return Optional.empty();
       }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManager.java
@@ -27,6 +27,7 @@ import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
 import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.util.ContextRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -44,13 +45,15 @@ public class DICodecsManager implements CodecsManager {
 
    private final Set<CodecProvider> codecProviders = new LinkedHashSet<>();
 
-   /**
-    * Injected constructor.
-    *
-    * @param codecProviders the CodecProvider
-    */
    @Inject
-   public DICodecsManager(final Set<CodecProvider> codecProviders) {
+   private ModelURIConverter uriConverter;
+
+   public DICodecsManager() {
+      super();
+   }
+
+   @Inject
+   private void addCodecProviders(final Set<CodecProvider> codecProviders) {
       this.codecProviders.addAll(codecProviders);
    }
 
@@ -90,7 +93,7 @@ public class DICodecsManager implements CodecsManager {
    @Override
    public JsonNode encode(final String modelUri, final WsContext context, final EObject eObject)
       throws EncodingException {
-      return findCodec(modelUri, context.queryParamMap()).encode(eObject);
+      return findCodec(modelUri, context).encode(eObject);
    }
 
    @Override
@@ -102,7 +105,9 @@ public class DICodecsManager implements CodecsManager {
    @Override
    public Optional<EObject> decode(final Context context, final String payload, final URI workspaceURI)
       throws DecodingException {
-      return findCodec(workspaceURI.toString(), context.queryParamMap()).decode(payload, workspaceURI);
+
+      URI modelUri = uriConverter.resolveModelURI(context).orElse(workspaceURI);
+      return findCodec(modelUri.toString(), context.queryParamMap()).decode(payload, workspaceURI);
    }
 
    @Override
@@ -114,7 +119,9 @@ public class DICodecsManager implements CodecsManager {
    @Override
    public Optional<EObject> decode(final WsContext context, final String payload, final URI workspaceURI)
       throws DecodingException {
-      return findCodec(workspaceURI.toString(), context).decode(payload, workspaceURI);
+
+      URI modelUri = uriConverter.resolveModelURI(context).orElse(workspaceURI);
+      return findCodec(modelUri.toString(), context).decode(payload, workspaceURI);
    }
 
    @Override

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManager.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManager.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emfcloud.modelserver.common.ModelServerPathParameters;
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV1;
 import org.eclipse.emfcloud.modelserver.common.codecs.Codec;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
@@ -40,10 +39,13 @@ import io.javalin.websocket.WsContext;
 public class DICodecsManager implements CodecsManager {
 
    protected static final Logger LOG = LogManager.getLogger(DICodecsManager.class);
-   /** The format we prefer to use. */
-   private String preferredFormat = ModelServerPathParameters.FORMAT_JSON;
+   /** The format we prefer to use. If {@code null}, then the preferred format is inferred from the API version. */
+   private String preferredFormat;
 
    private final Set<CodecProvider> codecProviders = new LinkedHashSet<>();
+
+   /** In support of the deprecated {@link #findCodec(String, Map)} method, only. */
+   private final ThreadLocal<Context> currentContext = new ThreadLocal<>();
 
    @Inject
    private ModelURIConverter uriConverter;
@@ -87,7 +89,7 @@ public class DICodecsManager implements CodecsManager {
    @Override
    public JsonNode encode(final String modelUri, final Context context, final EObject eObject)
       throws EncodingException {
-      return findCodec(modelUri, context.queryParamMap()).encode(eObject);
+      return findCodec(modelUri, context).encode(eObject);
    }
 
    @Override
@@ -99,7 +101,7 @@ public class DICodecsManager implements CodecsManager {
    @Override
    public Optional<EObject> decode(final String modelUri, final Context context, final String payload)
       throws DecodingException {
-      return findCodec(modelUri, context.queryParamMap()).decode(payload);
+      return findCodec(modelUri, context).decode(payload);
    }
 
    @Override
@@ -107,7 +109,7 @@ public class DICodecsManager implements CodecsManager {
       throws DecodingException {
 
       URI modelUri = uriConverter.resolveModelURI(context).orElse(workspaceURI);
-      return findCodec(modelUri.toString(), context.queryParamMap()).decode(payload, workspaceURI);
+      return findCodec(modelUri.toString(), context).decode(payload, workspaceURI);
    }
 
    @Override
@@ -133,14 +135,30 @@ public class DICodecsManager implements CodecsManager {
       return ModelServerPathParametersV1.FORMAT_JSON;
    }
 
+   public Codec findCodec(final String modelUri, final Context context) {
+      // We used the deprecated method, so delegate to it still
+      Context previous = currentContext.get();
+      currentContext.set(context);
+      try {
+         return findCodec(modelUri, context.queryParamMap());
+      } finally {
+         currentContext.set(previous);
+      }
+   }
+
    @Override
    public Codec findCodec(final String modelUri, final WsContext context) {
       String format = findFormat(context);
       return getCodec(modelUri, format).orElseGet(JsonCodec::new);
    }
 
+   /**
+    * @deprecated Override the {@link #findCodec(String, Context)} method, instead.
+    */
+   @Deprecated
    protected Codec findCodec(final String modelUri, final Map<String, List<String>> queryParams) {
-      String format = ContextRequest.getParam(queryParams, ModelServerPathParametersV1.FORMAT).orElse(preferredFormat);
+      String format = ContextRequest.getParam(queryParams, ModelServerPathParametersV1.FORMAT).orElseGet(
+         () -> Optional.ofNullable(currentContext.get()).map(this::getPreferredFormat).orElse(preferredFormat));
       return getCodec(modelUri, format).orElseGet(JsonCodec::new);
    }
 

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelControllerTest.java
@@ -144,6 +144,8 @@ public class DefaultModelControllerTest {
          }
       }).getInstance(DICodecsManager.class);
 
+      when(context.matchedPath()).thenReturn("/api/v1"); // This is all we need of the path for these tests
+
       when(modelRepository.getModel(getModelUri("TestError.ecore").toString()))
          .thenReturn(Optional.of(resource.get().getContents().get(0)));
       when(modelRepository.loadResource(getModelUri("TestError.ecore").toString())).thenReturn(resource);

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManagerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManagerTest.java
@@ -64,6 +64,7 @@ public class DICodecsManagerTest {
       super();
    }
 
+   @SuppressWarnings("deprecation")
    @Test
    public void encode_context() throws EncodingException {
       codecsManager.encode(modelUri, requestCtx, EcorePackage.Literals.EANNOTATION__SOURCE);
@@ -78,6 +79,7 @@ public class DICodecsManagerTest {
       verify(codecsManager).findCodec(modelUri, sessionCtx);
    }
 
+   @SuppressWarnings("deprecation")
    @Test
    public void decode_context() throws DecodingException {
       codecsManager.decode(modelUri, requestCtx, json);
@@ -92,6 +94,7 @@ public class DICodecsManagerTest {
       verify(codecsManager).findCodec(modelUri, sessionCtx);
    }
 
+   @SuppressWarnings("deprecation")
    @Test
    public void decode_contextWithWorkspaceURI() throws DecodingException {
       codecsManager.decode(requestCtx, json, WORKSPACE_URI);
@@ -121,6 +124,8 @@ public class DICodecsManagerTest {
 
       json = Json.object().set("eClass", Json.text(EcoreUtil.getURI(EcorePackage.Literals.EPACKAGE).toString()))
          .toString();
+
+      when(requestCtx.matchedPath()).thenReturn("/api/v1"); // This is all we need of the path for these tests
 
       codecsManager = spy(Guice.createInjector(new AbstractModule() {
          @Override

--- a/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManagerTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.emf.tests/src/org/eclipse/emfcloud/modelserver/emf/common/codecs/DICodecsManagerTest.java
@@ -1,0 +1,136 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common.codecs;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
+import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelURIConverter;
+import org.eclipse.emfcloud.modelserver.jsonschema.Json;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.TypeLiteral;
+
+import io.javalin.http.Context;
+import io.javalin.websocket.WsContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DICodecsManagerTest {
+
+   private static final URI WORKSPACE_URI = URI.createURI("bogus://my/workspace/directory/");
+   private static final URI MODEL_URI = URI.createURI("model.xml").resolve(WORKSPACE_URI);
+
+   private DICodecsManager codecsManager;
+
+   @Mock
+   private ModelURIConverter uriConverter;
+
+   @Mock
+   private Context requestCtx;
+
+   @Mock
+   private WsContext sessionCtx;
+
+   private final Map<String, List<String>> queryParams = Map.of();
+   private String modelUri;
+   private String json;
+
+   public DICodecsManagerTest() {
+      super();
+   }
+
+   @Test
+   public void encode_context() throws EncodingException {
+      codecsManager.encode(modelUri, requestCtx, EcorePackage.Literals.EANNOTATION__SOURCE);
+
+      verify(codecsManager).findCodec(modelUri, queryParams);
+   }
+
+   @Test
+   public void encode_wscontext() throws EncodingException {
+      codecsManager.encode(modelUri, sessionCtx, EcorePackage.Literals.EANNOTATION__SOURCE);
+
+      verify(codecsManager).findCodec(modelUri, sessionCtx);
+   }
+
+   @Test
+   public void decode_context() throws DecodingException {
+      codecsManager.decode(modelUri, requestCtx, json);
+
+      verify(codecsManager).findCodec(modelUri, queryParams);
+   }
+
+   @Test
+   public void decode_wscontext() throws DecodingException {
+      codecsManager.decode(modelUri, sessionCtx, json);
+
+      verify(codecsManager).findCodec(modelUri, sessionCtx);
+   }
+
+   @Test
+   public void decode_contextWithWorkspaceURI() throws DecodingException {
+      codecsManager.decode(requestCtx, json, WORKSPACE_URI);
+
+      // We looked up the codec by Model URI, not workspace URI
+      verify(codecsManager).findCodec(modelUri, queryParams);
+   }
+
+   @Test
+   public void decode_wscontextWithWorkspaceURI() throws DecodingException {
+      codecsManager.decode(sessionCtx, json, WORKSPACE_URI);
+
+      // We looked up the codec by Model URI, not workspace URI
+      verify(codecsManager).findCodec(modelUri, sessionCtx);
+   }
+
+   //
+   // Test framework
+   //
+
+   @Before
+   public void before() throws NoSuchFieldException, SecurityException {
+      when(requestCtx.queryParamMap()).thenReturn(queryParams);
+      when(uriConverter.resolveModelURI(requestCtx)).thenReturn(Optional.of(MODEL_URI));
+      when(uriConverter.resolveModelURI(sessionCtx)).thenReturn(Optional.of(MODEL_URI));
+      modelUri = MODEL_URI.toString();
+
+      json = Json.object().set("eClass", Json.text(EcoreUtil.getURI(EcorePackage.Literals.EPACKAGE).toString()))
+         .toString();
+
+      codecsManager = spy(Guice.createInjector(new AbstractModule() {
+         @Override
+         protected void configure() {
+            super.configure();
+
+            bind(ModelURIConverter.class).toInstance(uriConverter);
+            bind(new TypeLiteral<Set<CodecProvider>>() {}).toInstance(Set.of(new DefaultCodecsProvider()));
+         }
+      }).getInstance(DICodecsManager.class));
+   }
+
+}


### PR DESCRIPTION
Use the model URI provided by the request or session context if it is available.

Incidentally fix problems found in the `DefaultModelResourceManager` while debugging the issue in my application:

- catching all throwables, including `Error`s
- NPE in attempt to load a non-existent resource because the resource set is `null`

Fixes #245

Contributed on behalf of STMicroelectronics.
