### PR TITLE
Concurrency conflicts between Transaction- and ModelController

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelSynchronizer.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/DefaultModelSynchronizer.java
@@ -1,0 +1,127 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public final class DefaultModelSynchronizer implements ModelSynchronizer {
+
+   private static final AtomicInteger COUNTER = new AtomicInteger();
+
+   private final String name = DefaultModelSynchronizer.class.getSimpleName() + "-" + COUNTER.incrementAndGet();
+   private final Logger log = LogManager.getLogger(name);
+
+   private final ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+      Thread thread = new Thread(runnable, name);
+      thread.setDaemon(true);
+      return thread;
+   });
+
+   private final Semaphore executionPermits = new Semaphore(100);
+
+   public DefaultModelSynchronizer() {
+      super();
+   }
+
+   @Override
+   public void syncExec(final Runnable action) {
+      postAndWait(callable(action));
+   }
+
+   static Callable<Void> callable(final Runnable runnable) {
+      return () -> {
+         runnable.run();
+         return null;
+      };
+   }
+
+   @Override
+   public Future<Void> asyncExec(final Runnable action) {
+      return post(callable(action));
+   }
+
+   @Override
+   public <T> T syncCall(final Callable<T> action) {
+      return postAndWait(action);
+   }
+
+   @Override
+   public <T> Future<T> asyncCall(final Callable<T> action) {
+      return post(action);
+   }
+
+   private <T> Future<T> post(final Callable<T> action) {
+      for (;;) {
+         if (executor.isShutdown()) {
+            // This may happen if e.g. some background tasks were still running when the client disconnected.
+            // This (probably) isn't critical and can be safely ignored.
+            log.warn(String.format(
+               "Received an action after the synchronizer was stopped. Ignoring action: %s", action));
+            return CompletableFuture.failedFuture(new IllegalStateException("Synchronizer shut down"));
+         }
+
+         try {
+            if (executionPermits.tryAcquire(1, TimeUnit.SECONDS)) {
+               return executor.submit(() -> {
+                  T result;
+
+                  try {
+                     result = action.call();
+                  } finally {
+                     // Release our execution permit for the next task to pick up
+                     executionPermits.release();
+                  }
+
+                  return result;
+               });
+            }
+
+            log.warn(String.format("Queue is currently full; retrying..."));
+         } catch (final InterruptedException e) {
+            log.error("Interrupted while waiting to post model action.", e);
+            return CompletableFuture.failedFuture(e);
+         }
+      }
+   }
+
+   private <T> T postAndWait(final Callable<T> action) {
+      Future<T> result = post(action);
+      while (true) {
+         try {
+            return result.get(1, TimeUnit.SECONDS);
+         } catch (TimeoutException ex) {
+            // FIXME: Should we add a specific timeout? Most actions shouldn't take too long to execute,
+            // but if something goes wrong, we may wait forever.
+            log.warn("A model action is taking a long time to execute. Keep waiting... " + (ex.getMessage() == null ? ""
+               : ex.getMessage()));
+         } catch (InterruptedException e) {
+            log.error("Interrupted", e);
+            return null;
+         } catch (ExecutionException e) {
+            log.error("Execution Exception", e);
+            return null;
+         }
+      }
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelSynchronizer.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/ModelSynchronizer.java
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+/**
+ * A service for synchronization of model edits and/or accesses in a serial queue
+ * on one or more threads for safe concurrency.
+ */
+public interface ModelSynchronizer {
+
+   /**
+    * Execute a model read or write action without result and wait for it to finish.
+    *
+    * @param action an action on the model(s)
+    */
+   void syncExec(Runnable action);
+
+   /**
+    * Execute a model read or write action without result.
+    *
+    * @param action an action on the model(s)
+    * @return a future that will notify when the {@code code} has completed
+    */
+   Future<Void> asyncExec(Runnable action);
+
+   /**
+    * Execute a model read or write action with a result.
+    *
+    * @param action an action on the model(s)
+    * @return the result of the {@code action}, or {@code null} (with a log) if it failed
+    */
+   <T> T syncCall(Callable<T> action);
+
+   /**
+    * Execute a model read or write action with a result.
+    *
+    * @param action an action on the model(s)
+    * @return the future result of the {@code action}
+    */
+   <T> Future<T> asyncCall(Callable<T> action);
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SingleThreadModelController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SingleThreadModelController.java
@@ -10,17 +10,6 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.emf.common;
 
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
@@ -41,59 +30,27 @@ public class SingleThreadModelController implements ModelController {
     */
    public static final String MODEL_CONTROLLER_DELEGATE = "ModelControllerDelegate";
 
-   private static final Logger LOG = LogManager.getLogger(SingleThreadModelController.class);
-
-   private static final AtomicInteger COUNT = new AtomicInteger(0);
-
    protected final ModelController delegate;
 
-   protected final Thread thread;
-
-   protected final BlockingQueue<Runnable> actionsQueue = new ArrayBlockingQueue<>(100, true);
-
-   protected final String name;
+   protected final ModelSynchronizer synchronizer;
 
    @Inject
-   public SingleThreadModelController(final @Named(MODEL_CONTROLLER_DELEGATE) ModelController delegate) {
-      this.name = getClass().getSimpleName() + " " + COUNT.incrementAndGet();
+   public SingleThreadModelController(final @Named(MODEL_CONTROLLER_DELEGATE) ModelController delegate,
+      final ModelSynchronizer synchronizer) {
       this.delegate = delegate;
-      this.thread = new Thread(this::runThread);
-      this.thread.setName(this.name);
-      this.thread.setDaemon(true);
-      this.thread.start();
+      this.synchronizer = synchronizer;
    }
 
-   private void runThread() {
-      while (true) {
-         try {
-            handleNextAction();
-         } catch (final InterruptedException e) {
-            LOG.info(
-               String.format("Terminating SingleThreadModelController thread %s", Thread.currentThread().getName()));
-            break;
-         }
-      }
-      LOG.info("Terminating SingleThreadModelController");
-   }
-
-   private void handleNextAction()
-      throws InterruptedException {
-      final Runnable runnable = actionsQueue.take();
-      if (runnable != null) {
-         handleAction(runnable);
-      }
-   }
-
+   /** @deprecated this method is no longer used */
+   @Deprecated
    protected void handleAction(final Runnable runnable) {
-      checkThread();
-      runnable.run();
+      // No-op
    }
 
+   /** @deprecated this method is no longer used */
+   @Deprecated
    protected final void checkThread() {
-      if (Thread.currentThread() != thread) {
-         throw new IllegalStateException(
-            "This method should only be invoked from the ModelControllers's thread: " + name);
-      }
+      // No-op
    }
 
    //
@@ -102,139 +59,87 @@ public class SingleThreadModelController implements ModelController {
 
    @Override
    public void create(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.create(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.create(ctx, modeluri));
    }
 
    @Override
    public void delete(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.delete(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.delete(ctx, modeluri));
    }
 
    @Override
    public void getAll(final Context ctx) {
-      runAndWait(() -> delegate.getAll(ctx));
+      synchronizer.syncExec(() -> delegate.getAll(ctx));
    }
 
    @Override
    public void getOne(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.getOne(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.getOne(ctx, modeluri));
    }
 
    @Override
    public void getModelElementById(final Context ctx, final String modeluri, final String elementid) {
-      runAndWait(() -> delegate.getModelElementById(ctx, modeluri, elementid));
+      synchronizer.syncExec(() -> delegate.getModelElementById(ctx, modeluri, elementid));
    }
 
    @Override
    public void getModelElementByName(final Context ctx, final String modeluri, final String elementname) {
-      runAndWait(() -> delegate.getModelElementByName(ctx, modeluri, elementname));
+      synchronizer.syncExec(() -> delegate.getModelElementByName(ctx, modeluri, elementname));
    }
 
    @Override
    public void getModelUris(final Context ctx) {
-      runAndWait(() -> delegate.getModelUris(ctx));
+      synchronizer.syncExec(() -> delegate.getModelUris(ctx));
    }
 
    @Override
    public void update(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.update(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.update(ctx, modeluri));
    }
 
    @Override
    public void save(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.save(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.save(ctx, modeluri));
    }
 
    @Override
    public void saveAll(final Context ctx) {
-      runAndWait(() -> delegate.saveAll(ctx));
+      synchronizer.syncExec(() -> delegate.saveAll(ctx));
    }
 
    @Override
    public void validate(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.validate(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.validate(ctx, modeluri));
    }
 
    @Override
    public void getValidationConstraints(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.getValidationConstraints(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.getValidationConstraints(ctx, modeluri));
    }
 
    @Override
    public void executeCommand(final Context ctx, final String modelURI) {
-      runAndWait(() -> delegate.executeCommand(ctx, modelURI));
+      synchronizer.syncExec(() -> delegate.executeCommand(ctx, modelURI));
    }
 
    @Override
    public void executeCommandV2(final Context ctx, final String modelURI) {
-      runAndWait(() -> delegate.executeCommandV2(ctx, modelURI));
+      synchronizer.syncExec(() -> delegate.executeCommandV2(ctx, modelURI));
    }
 
    @Override
    public void undo(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.undo(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.undo(ctx, modeluri));
    }
 
    @Override
    public void redo(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.redo(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.redo(ctx, modeluri));
    }
 
    @Override
    public void close(final Context ctx, final String modeluri) {
-      runAndWait(() -> delegate.close(ctx, modeluri));
+      synchronizer.syncExec(() -> delegate.close(ctx, modeluri));
    }
 
-   /**
-    * Executes the given action in the Model thread, and wait for it to complete.
-    *
-    * @param action
-    *                  The action to execute.
-    */
-   private void runAndWait(final Runnable action) {
-      FutureTask<Void> task = new FutureTask<>(action, null);
-      boolean success = actionsQueue.offer(task);
-      while (!success) {
-         if (!thread.isAlive() || thread.isInterrupted()) {
-            // This may happen if e.g. some background tasks were still running when the client disconnected.
-            // This (probably) isn't critical and can be safely ignored.
-            LOG.warn(String.format(
-               "Received an action after the ModelController was stopped. Ignoring action: %s", action));
-            return;
-         }
-         try {
-            // The queue may be temporarily full because we receive a lot of messages (e.g. during initialization),
-            // but if this keeps failing for a long time, it might indicate a deadlock
-            success = actionsQueue.offer(action, 1, TimeUnit.SECONDS);
-            if (!success) {
-               LOG.warn(String.format("Actions queue is currently full for ModelController %s ; retrying...", name));
-            }
-         } catch (final InterruptedException ex) {
-            break;
-         }
-      }
-
-      // We need to wait for the task to complete, because the context
-      // will be closed/disposed when this method returns.
-      waitComplete(task);
-   }
-
-   private void waitComplete(final FutureTask<Void> task) {
-      while (true) {
-         try {
-            task.get(1, TimeUnit.SECONDS);
-            return;
-         } catch (TimeoutException ex) {
-            // FIXME: Should we add a specific timeout? Most actions shouldn't take too long to execute,
-            // but if something goes wrong, we may wait forever.
-            LOG.warn("A ModelController action is taking a long time to execute. Keep waiting... " + ex.getMessage());
-         } catch (InterruptedException e) {
-            LOG.error("Interrupted", e);
-            return;
-         } catch (ExecutionException e) {
-            LOG.error("Execution Exception", e);
-            return;
-         }
-      }
-   }
 }

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SingleThreadTransactionController.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/common/SingleThreadTransactionController.java
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.emf.common;
+
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.URI;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import io.javalin.http.Context;
+import io.javalin.websocket.WsCloseContext;
+import io.javalin.websocket.WsConnectContext;
+import io.javalin.websocket.WsContext;
+import io.javalin.websocket.WsErrorContext;
+import io.javalin.websocket.WsMessageContext;
+
+/**
+ * A {@link TransactionController} that executes all requests in the same thread, to
+ * ensure we use a consistent resource set state.
+ */
+public class SingleThreadTransactionController implements TransactionController {
+   /**
+    * Dependency injection name for the actual Transaction Controller implementation,
+    * to which the {@link SingleThreadTransactionController} will delegate calls
+    * in serial order on a single thread.
+    *
+    * @see Named
+    */
+   public static final String TRANSACTION_CONTROLLER_DELEGATE = "TransactionControllerDelegate";
+
+   protected final TransactionController delegate;
+
+   protected final ModelSynchronizer synchronizer;
+
+   @Inject
+   public SingleThreadTransactionController(
+      final @Named(TRANSACTION_CONTROLLER_DELEGATE) TransactionController delegate,
+      final ModelSynchronizer synchronizer) {
+
+      super();
+
+      this.delegate = delegate;
+      this.synchronizer = synchronizer;
+   }
+
+   //
+   // Delegation
+   //
+
+   @Override
+   public void create(final Context ctx, final String modeluri) {
+      synchronizer.syncExec(() -> delegate.create(ctx, modeluri));
+   }
+
+   @Override
+   public void onOpen(final WsConnectContext ctx) {
+      synchronizer.syncExec(() -> delegate.onOpen(ctx));
+   }
+
+   @Override
+   public void onClose(final WsCloseContext ctx) {
+      synchronizer.syncExec(() -> delegate.onClose(ctx));
+   }
+
+   @Override
+   public void onError(final WsErrorContext ctx) {
+      synchronizer.syncExec(() -> delegate.onError(ctx));
+   }
+
+   @Override
+   public void onMessage(final WsMessageContext ctx) {
+      synchronizer.syncExec(() -> delegate.onMessage(ctx));
+   }
+
+   @Override
+   public Optional<URI> getModelURI(final WsContext ctx) {
+      Optional<URI> result = synchronizer.syncCall(() -> delegate.getModelURI(ctx));
+      return result == null ? Optional.empty() : result;
+   }
+
+}

--- a/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.emf/src/org/eclipse/emfcloud/modelserver/emf/di/DefaultModelServerModule.java
@@ -29,6 +29,7 @@ import org.eclipse.emfcloud.modelserver.edit.DICommandCodec;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultFacetConfig;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelController;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelRepository;
+import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelSynchronizer;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelValidator;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultResourceSetFactory;
@@ -41,6 +42,7 @@ import org.eclipse.emfcloud.modelserver.emf.common.DefaultUriHelper;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelController;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelSynchronizer;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelURIConverter;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelValidator;
 import org.eclipse.emfcloud.modelserver.emf.common.RecordingModelResourceManager;
@@ -50,6 +52,7 @@ import org.eclipse.emfcloud.modelserver.emf.common.SchemaRepository;
 import org.eclipse.emfcloud.modelserver.emf.common.ServerController;
 import org.eclipse.emfcloud.modelserver.emf.common.SessionController;
 import org.eclipse.emfcloud.modelserver.emf.common.SingleThreadModelController;
+import org.eclipse.emfcloud.modelserver.emf.common.SingleThreadTransactionController;
 import org.eclipse.emfcloud.modelserver.emf.common.TransactionController;
 import org.eclipse.emfcloud.modelserver.emf.common.UriHelper;
 import org.eclipse.emfcloud.modelserver.emf.common.codecs.CodecProvider;
@@ -104,10 +107,11 @@ public class DefaultModelServerModule extends ModelServerModule {
       bind(ModelValidator.class).to(bindModelValidator()).in(Singleton.class);
       bind(FacetConfig.class).to(bindFacetConfig()).in(Singleton.class);
       bind(UriHelper.class).to(bindUriHelper()).in(Singleton.class);
-      bind(TransactionController.class).to(bindTransactionController()).in(Singleton.class);
+      bind(TransactionController.class).to(bindThreadSafeTransactionController()).in(Singleton.class);
       bind(ModelURIConverter.class).to(bindModelURIConverter()).in(Singleton.class);
       bind(ResourceSetFactory.class).to(bindResourceSetFactory()).in(Singleton.class);
       bind(URIConverter.class).to(Key.get(ModelURIConverter.class));
+      bind(ModelSynchronizer.class).to(bindModelSynchronizer()).in(Singleton.class);
 
       // Configure instance bindings
       bind(ObjectMapper.class).toProvider(this::provideObjectMapper).in(Singleton.class);
@@ -132,6 +136,10 @@ public class DefaultModelServerModule extends ModelServerModule {
 
    protected Class<? extends JsonSchemaConverter> bindJsonSchemaConverter() {
       return DefaultJsonSchemaConverter.class;
+   }
+
+   protected Class<? extends ModelSynchronizer> bindModelSynchronizer() {
+      return DefaultModelSynchronizer.class;
    }
 
    protected Class<? extends ModelController> bindModelController() {
@@ -198,6 +206,13 @@ public class DefaultModelServerModule extends ModelServerModule {
 
    protected Class<? extends TransactionController> bindTransactionController() {
       return DefaultTransactionController.class;
+   }
+
+   protected Class<? extends TransactionController> bindThreadSafeTransactionController() {
+      bind(TransactionController.class)
+         .annotatedWith(Names.named(SingleThreadTransactionController.TRANSACTION_CONTROLLER_DELEGATE))
+         .to(bindTransactionController());
+      return SingleThreadTransactionController.class;
    }
 
    protected Class<? extends ModelURIConverter> bindModelURIConverter() {


### PR DESCRIPTION
Extract the single-thread execution mechanism from the `SingleThreadModelController` and generalize it, rebuilding it on the Java `ExecutorService`, as an injectable `ModelSynchronizer` service that is now also used by a new `SingleThreadTransactionController`.

Bind the new `SingleThreadTransactionController` by default.

Fixes #250

Contributed on behalf of STMicroelectronics.
