### PR TITLE
With command edit API, use SetCommand on a containment feature (#257)

### DIFF
--- a/bundles/org.eclipse.emfcloud.modelserver.edit/src/org/eclipse/emfcloud/modelserver/edit/command/SetCommandContribution.java
+++ b/bundles/org.eclipse.emfcloud.modelserver.edit/src/org/eclipse/emfcloud/modelserver/edit/command/SetCommandContribution.java
@@ -16,6 +16,7 @@ import static org.eclipse.emf.common.notify.Notification.NO_INDEX;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -51,6 +52,8 @@ public class SetCommandContribution extends BasicCommandContribution<SetCommand>
          EDataType dataType = ((EAttribute) feature).getEAttributeType();
          value = command.getDataValues().isEmpty() ? null
             : EcoreUtil.createFromString(dataType, command.getDataValues().get(0));
+      } else if(feature instanceof EReference && ((EReference)feature).isContainment()) {
+         value = getFirst(command.getObjectsToAdd(), null);
       } else {
          value = getFirst(command.getObjectValues(), null);
       }

--- a/tests/org.eclipse.emfcloud.modelserver.edit.tests/src/org/eclipse/emfcloud/modelserver/edit/EMFCommandCodecTest.java
+++ b/tests/org.eclipse.emfcloud.modelserver.edit.tests/src/org/eclipse/emfcloud/modelserver/edit/EMFCommandCodecTest.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EGenericType;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
@@ -62,6 +63,7 @@ public class EMFCommandCodecTest {
    private static final String N_A = "n/a";
    private static final String ATTRIBUTE = "attribute";
    private static final String REFERENCE = "reference";
+   private static final String MONO_CONTAINMENT = "monovalued containment reference";
    private static final String REFERENCE_MANY = "reference (many)";
    private static final String REFERENCE_BY_INDEX = "reference (by index)";
 
@@ -107,6 +109,7 @@ public class EMFCommandCodecTest {
          new Object[] { EMFCommandType.SET, ATTRIBUTE, createAttributeSetCommand(),
             createAttributeSetModel() }, //
          new Object[] { EMFCommandType.SET, REFERENCE, createReferenceSetCommand(), createReferenceSetModel() }, //
+         new Object[] { EMFCommandType.SET, MONO_CONTAINMENT, createMonoContainmentSetCommand(), createMonoContainmentSetModel() }, //
          new Object[] { EMFCommandType.ADD, ATTRIBUTE, createAttributeAddCommand(), createAttributeAddModel() }, //
          new Object[] { EMFCommandType.ADD, REFERENCE, createReferenceAddCommand(), createReferenceAddModel() }, //
          new Object[] { EMFCommandType.ADD, REFERENCE_MANY, createReferenceAddMultipleCommand(),
@@ -172,6 +175,25 @@ public class EMFCommandCodecTest {
       result.getObjectValues().add(newClass);
       result.getObjectsToAdd().add(newClass);
       result.getIndices().add(1);
+      return result;
+   }
+
+   static Command createMonoContainmentSetCommand() {
+      EGenericType newGenericType = EcoreFactory.eINSTANCE.createEGenericType();
+
+      return SetCommand.create(domain, ((EClass)ePackage.getEClassifiers().get(0)).getEStructuralFeatures().get(0), EcorePackage.Literals.ETYPED_ELEMENT__EGENERIC_TYPE, newGenericType);
+   }
+
+   static CCommand createMonoContainmentSetModel() {
+      EGenericType newGenericType = EcoreFactory.eINSTANCE.createEGenericType();
+
+      CCommand result = CCommandFactory.eINSTANCE.createCommand();
+      result.setType(EMFCommandType.SET);
+      result.setOwner(((EClass)ePackage.getEClassifiers().get(0)).getEStructuralFeatures().get(0));
+      result.setFeature("eGenericType");
+      result.getObjectValues().add(newGenericType);
+      result.getObjectsToAdd().add(newGenericType);
+      result.getIndices().add(NO_INDEX);
       return result;
    }
 


### PR DESCRIPTION
Fixing SetCommandContribution:
enable usage of SetCommand on monovalued containment features.

Signed-off-by: vhemery <vincent.hemery@bonitasoft.com>