### PR TITLE
Fix PrintUtil for multi-valued attributes

### DIFF
--- a/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/util/PrintUtil.java
+++ b/examples/org.eclipse.emfcloud.modelserver.example/src/main/java/org/eclipse/emfcloud/modelserver/example/util/PrintUtil.java
@@ -10,6 +10,10 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.example.util;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -122,8 +126,16 @@ public final class PrintUtil {
          beginObject(object.eClass().getName() + " {");
 
          for (EAttribute attr : object.eClass().getEAllAttributes()) {
-            print(String.format("%s: %s", attr.getName(),
-               EcoreUtil.convertToString(attr.getEAttributeType(), object.eGet(attr))));
+            Object value = object.eGet(attr);
+            if (attr.isMany()) {
+               Stream<String> printableValues = ((Collection<?>) value).stream()
+                  .map(v -> EcoreUtil.convertToString(attr.getEAttributeType(), v));
+               print(String.format("%s: %s", attr.getName(),
+                  printableValues.collect(Collectors.toList()).toString()));
+            } else {
+               print(String.format("%s: %s", attr.getName(),
+                  EcoreUtil.convertToString(attr.getEAttributeType(), value)));
+            }
          }
 
          recurse(object);


### PR DESCRIPTION
Displays multi-valued attributes correctly.

The example plugin does not have tests, and registered models do not have mutivalued attributes.
Adding a new test module may not be relevant.
However, one can simply test this fix by executing :
```
package org.eclipse.emfcloud.modelserver.example.util;

import java.util.List;

import org.eclipse.emf.common.util.EList;
import org.eclipse.emf.ecore.EcoreFactory;
import org.eclipse.emf.ecore.EcorePackage;
import org.eclipse.emf.ecore.util.EcoreUtil;

public class PrintUtilTest {

   public static void main(final String[] args) {
      var ep = EcoreFactory.eINSTANCE.createEPackage();
      ep.setName("testModel");
      var ec = EcoreFactory.eINSTANCE.createEClass();
      ec.setName("TestManyAttribute");
      var att = EcoreFactory.eINSTANCE.createEAttribute();
      att.setName("values");
      att.setEType(EcorePackage.Literals.ESTRING);
      att.setUpperBound(-1);
      ec.getEStructuralFeatures().add(att);
      ep.getEClassifiers().add(ec);

      var obj = EcoreUtil.create(ec);
      EList<String> values = (EList<String>) obj.eGet(att);
      values.addAll(List.of("1", "2", "3"));
      // displays value successfully as "values: [1, 2, 3]"
      System.out.println(PrintUtil.toPrettyString(obj));
   }

}
```

Fixes #276