### PR TITLE
Add code coverage for jacoco.

### DIFF
--- a/releng/org.eclipse.emfcloud.modelserver.codecoverage/pom.xml
+++ b/releng/org.eclipse.emfcloud.modelserver.codecoverage/pom.xml
@@ -15,9 +15,15 @@
    </properties>
 
    <dependencies>
+      <!-- We have to repeat every tested bundle here :'( -->
       <dependency>
          <groupId>org.eclipse.emfcloud.modelserver</groupId>
          <artifactId>org.eclipse.emfcloud.modelserver.client</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.emfcloud.modelserver</groupId>
+         <artifactId>org.eclipse.emfcloud.modelserver.client.tests</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -27,12 +33,27 @@
       </dependency>
       <dependency>
          <groupId>org.eclipse.emfcloud.modelserver</groupId>
+         <artifactId>org.eclipse.emfcloud.modelserver.common.tests</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.emfcloud.modelserver</groupId>
          <artifactId>org.eclipse.emfcloud.modelserver.emf</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
          <groupId>org.eclipse.emfcloud.modelserver</groupId>
+         <artifactId>org.eclipse.emfcloud.modelserver.emf.tests</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.emfcloud.modelserver</groupId>
          <artifactId>org.eclipse.emfcloud.modelserver.edit</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.emfcloud.modelserver</groupId>
+         <artifactId>org.eclipse.emfcloud.modelserver.edit.tests</artifactId>
          <version>${project.version}</version>
       </dependency>
    </dependencies>
@@ -46,7 +67,7 @@
             <executions>
                <execution>
                   <id>report-code-coverage</id>
-                  <phase>test</phase>
+                  <phase>verify</phase>
                   <goals>
                      <goal>report-aggregate</goal>
                   </goals>


### PR DESCRIPTION
Report coverage correctly on verify phase with all test dependencies.

Does not implement the PR check suggested in [eneufeld's comment](https://github.com/eclipse-emfcloud/emfcloud-modelserver/issues/266#issuecomment-1386955405)

Fixes #266